### PR TITLE
유저 서비스 리포지토리 구현

### DIFF
--- a/src/main/java/com/stemm/pubsub/common/BaseEntity.java
+++ b/src/main/java/com/stemm/pubsub/common/BaseEntity.java
@@ -10,9 +10,9 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-@MappedSuperclass
 public abstract class BaseEntity {
     @CreatedDate
     @Column(updatable = false, nullable = false)

--- a/src/main/java/com/stemm/pubsub/service/post/entity/Comment.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/Comment.java
@@ -1,6 +1,7 @@
 package com.stemm.pubsub.service.post.entity;
 
 import com.stemm.pubsub.common.BaseEntity;
+import com.stemm.pubsub.service.post.entity.post.Post;
 import com.stemm.pubsub.service.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/stemm/pubsub/service/post/entity/LikeStatus.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/LikeStatus.java
@@ -1,6 +1,0 @@
-package com.stemm.pubsub.service.post.entity;
-
-public enum LikeStatus {
-    LIKE,
-    DISLIKE
-}

--- a/src/main/java/com/stemm/pubsub/service/post/entity/post/LikeStatus.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/post/LikeStatus.java
@@ -1,0 +1,6 @@
+package com.stemm.pubsub.service.post.entity.post;
+
+public enum LikeStatus {
+    LIKE,
+    DISLIKE
+}

--- a/src/main/java/com/stemm/pubsub/service/post/entity/post/Post.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/post/Post.java
@@ -1,4 +1,4 @@
-package com.stemm.pubsub.service.post.entity;
+package com.stemm.pubsub.service.post.entity.post;
 
 import com.stemm.pubsub.common.BaseEntity;
 import com.stemm.pubsub.service.user.entity.User;
@@ -12,29 +12,33 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
+@Table(indexes = @Index(name = "idx_post_created_date", columnList = "created_date"))
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class PostLike extends BaseEntity {
+public class Post extends BaseEntity {
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "post_like_id")
+    @Column(name = "post_id")
     private Long id;
-
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "post_id")
-    private Post post;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
+    @Lob
+    @Column(nullable = false)
+    private String content;
+
+    private String imageUrl;
+
     @Enumerated(STRING)
     @Column(nullable = false)
-    private LikeStatus status;
+    private Visibility visibility;
 
-    public PostLike(Post post, User user, LikeStatus status) {
-        this.post = post;
+    public Post(User user, String content, String imageUrl, Visibility visibility) {
         this.user = user;
-        this.status = status;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.visibility = visibility;
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/post/entity/post/PostLike.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/post/PostLike.java
@@ -1,4 +1,4 @@
-package com.stemm.pubsub.service.post.entity;
+package com.stemm.pubsub.service.post.entity.post;
 
 import com.stemm.pubsub.common.BaseEntity;
 import com.stemm.pubsub.service.user.entity.User;
@@ -12,33 +12,29 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
-@Table(indexes = @Index(name = "idx_post_created_date", columnList = "created_date"))
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Post extends BaseEntity {
+public class PostLike extends BaseEntity {
     @Id
     @GeneratedValue(strategy = IDENTITY)
-    @Column(name = "post_id")
+    @Column(name = "post_like_id")
     private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @Lob
-    @Column(nullable = false)
-    private String content;
-
-    private String imageUrl;
-
     @Enumerated(STRING)
     @Column(nullable = false)
-    private Visibility visibility;
+    private LikeStatus status;
 
-    public Post(User user, String content, String imageUrl, Visibility visibility) {
+    public PostLike(Post post, User user, LikeStatus status) {
+        this.post = post;
         this.user = user;
-        this.content = content;
-        this.imageUrl = imageUrl;
-        this.visibility = visibility;
+        this.status = status;
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/post/entity/post/Visibility.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/post/Visibility.java
@@ -1,4 +1,4 @@
-package com.stemm.pubsub.service.post.entity;
+package com.stemm.pubsub.service.post.entity.post;
 
 public enum Visibility {
     PUBLIC,

--- a/src/main/java/com/stemm/pubsub/service/user/entity/User.java
+++ b/src/main/java/com/stemm/pubsub/service/user/entity/User.java
@@ -28,7 +28,7 @@ public class User extends BaseEntity {
     private Membership membership;
 
     @Column(nullable = false, unique = true)
-    private String username;
+    private String nickname;
 
     @Column(nullable = false)
     private String name;
@@ -44,14 +44,14 @@ public class User extends BaseEntity {
     @Builder
     private User(
         Membership membership,
-        String username,
+        String nickname,
         String name,
         String email,
         String profileImageUrl,
         String bio
     ) {
         this.membership = membership;
-        this.username = username;
+        this.nickname = nickname;
         this.name = name;
         this.email = email;
         this.profileImageUrl = profileImageUrl;

--- a/src/main/java/com/stemm/pubsub/service/user/entity/subscription/Subscription.java
+++ b/src/main/java/com/stemm/pubsub/service/user/entity/subscription/Subscription.java
@@ -1,6 +1,8 @@
-package com.stemm.pubsub.service.user.entity;
+package com.stemm.pubsub.service.user.entity.subscription;
 
 import com.stemm.pubsub.common.BaseEntity;
+import com.stemm.pubsub.service.user.entity.Membership;
+import com.stemm.pubsub.service.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/stemm/pubsub/service/user/entity/subscription/SubscriptionStatus.java
+++ b/src/main/java/com/stemm/pubsub/service/user/entity/subscription/SubscriptionStatus.java
@@ -1,4 +1,4 @@
-package com.stemm.pubsub.service.user.entity;
+package com.stemm.pubsub.service.user.entity.subscription;
 
 public enum SubscriptionStatus {
     ACTIVE,

--- a/src/main/java/com/stemm/pubsub/service/user/repository/MembershipRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/MembershipRepository.java
@@ -1,0 +1,7 @@
+package com.stemm.pubsub.service.user.repository;
+
+import com.stemm.pubsub.service.user.entity.Membership;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MembershipRepository extends JpaRepository<Membership, Long> {
+}

--- a/src/main/java/com/stemm/pubsub/service/user/repository/UserRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.stemm.pubsub.service.user.repository;
+
+import com.stemm.pubsub.service.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findUserByNickname(String nickname);
+}

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/CustomSubscriptionRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/CustomSubscriptionRepository.java
@@ -1,0 +1,10 @@
+package com.stemm.pubsub.service.user.repository.subscription;
+
+import com.stemm.pubsub.service.user.entity.subscription.Subscription;
+
+import java.util.List;
+
+public interface CustomSubscriptionRepository {
+    List<Subscription> findNewestSubscriptions(Long userId);
+    List<Subscription> findOldestSubscriptions(Long userId);
+}

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/CustomSubscriptionRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/CustomSubscriptionRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.stemm.pubsub.service.user.repository.subscription;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.stemm.pubsub.service.user.entity.subscription.Subscription;
+import jakarta.persistence.EntityManager;
+
+import java.util.List;
+
+import static com.stemm.pubsub.service.user.entity.subscription.QSubscription.subscription;
+import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
+
+public class CustomSubscriptionRepositoryImpl implements CustomSubscriptionRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CustomSubscriptionRepositoryImpl(EntityManager entityManager) {
+        queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public List<Subscription> findNewestSubscriptions(Long userId) {
+        return queryFactory
+            .selectFrom(subscription)
+            .where(userIdEquals(userId), isActive())
+            .orderBy(subscription.createdDate.desc())
+            .fetch();
+    }
+
+    @Override
+    public List<Subscription> findOldestSubscriptions(Long userId) {
+        return queryFactory
+            .selectFrom(subscription)
+            .where(userIdEquals(userId), isActive())
+            .orderBy(subscription.createdDate.asc())
+            .fetch();
+    }
+
+    private BooleanExpression userIdEquals(Long userId) {
+        return subscription.user.id.eq(userId);
+    }
+
+    private BooleanExpression isActive() {
+        return subscription.status.eq(ACTIVE);
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionRepository.java
@@ -1,0 +1,7 @@
+package com.stemm.pubsub.service.user.repository.subscription;
+
+import com.stemm.pubsub.service.user.entity.subscription.Subscription;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubscriptionRepository extends JpaRepository<Subscription, Long>, CustomSubscriptionRepository {
+}

--- a/src/test/java/com/stemm/pubsub/common/utils/DataJpaTestWithAuditing.java
+++ b/src/test/java/com/stemm/pubsub/common/utils/DataJpaTestWithAuditing.java
@@ -1,0 +1,17 @@
+package com.stemm.pubsub.common.utils;
+
+import com.stemm.pubsub.common.config.JpaAuditingConfig;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+public @interface DataJpaTestWithAuditing {
+}

--- a/src/test/java/com/stemm/pubsub/service/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/UserRepositoryTest.java
@@ -1,19 +1,16 @@
 package com.stemm.pubsub.service.user.repository;
 
-import com.stemm.pubsub.common.config.JpaAuditingConfig;
+import com.stemm.pubsub.common.utils.DataJpaTestWithAuditing;
 import com.stemm.pubsub.service.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTest
-@Import(JpaAuditingConfig.class)
+@DataJpaTestWithAuditing
 class UserRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/stemm/pubsub/service/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/UserRepositoryTest.java
@@ -1,0 +1,47 @@
+package com.stemm.pubsub.service.user.repository;
+
+import com.stemm.pubsub.common.config.JpaAuditingConfig;
+import com.stemm.pubsub.service.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditingConfig.class)
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("닉네임으로 유저를 조회합니다.")
+    void findUserByNickname() {
+        // given
+        String nickname = "user1";
+        User user1 = createUser(nickname, "name1", "user1@email.com");
+        User user2 = createUser("user2", "name2", "user2@email.com");
+        User user3 = createUser("user3", "name3", "user3@email.com");
+        userRepository.saveAll(List.of(user1, user2, user3));
+
+        // when
+        User foundUser = userRepository.findUserByNickname(nickname);
+
+        // then
+        assertThat(foundUser)
+            .hasFieldOrPropertyWithValue("nickname", nickname);
+    }
+
+    private User createUser(String nickname, String name, String email) {
+        return User.builder()
+            .nickname(nickname)
+            .name(name)
+            .email(email)
+            .build();
+    }
+}

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionRepositoryTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionRepositoryTest.java
@@ -1,0 +1,93 @@
+package com.stemm.pubsub.service.user.repository.subscription;
+
+import com.stemm.pubsub.common.utils.DataJpaTestWithAuditing;
+import com.stemm.pubsub.service.user.entity.Membership;
+import com.stemm.pubsub.service.user.entity.User;
+import com.stemm.pubsub.service.user.entity.subscription.Subscription;
+import com.stemm.pubsub.service.user.repository.MembershipRepository;
+import com.stemm.pubsub.service.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.reverseOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTestWithAuditing
+class SubscriptionRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MembershipRepository membershipRepository;
+
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
+    @Test
+    @DisplayName("유저가 구독한 멤버십을 최신 순으로 조회합니다.")
+    void findNewestSubscriptions() {
+        // given
+        User user = User.builder()
+            .nickname("a")
+            .name("user")
+            .email("a@me.com")
+            .build();
+        userRepository.save(user);
+
+        Membership membership1 = new Membership("membership1", 10_000);
+        Membership membership2 = new Membership("membership2", 50_000);
+        Membership membership3 = new Membership("membership3", 8_000);
+        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
+
+        Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
+        Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
+        Subscription subscription3 = new Subscription(user, membership3, ACTIVE);
+        subscriptionRepository.saveAll(List.of(subscription1, subscription2, subscription3));
+
+        // when
+        List<Subscription> newestSubscriptions = subscriptionRepository.findNewestSubscriptions(user.getId());
+
+        // then
+        assertThat(newestSubscriptions)
+            .hasSize(3)
+            .extracting(Subscription::getCreatedDate)
+            .isSortedAccordingTo(reverseOrder());
+    }
+
+    @Test
+    @DisplayName("유저가 구독한 멤버십을 오래된 순으로 조회합니다.")
+    void findOldestSubscriptions() {
+        // given
+        User user = User.builder()
+            .nickname("a")
+            .name("user")
+            .email("a@me.com")
+            .build();
+        userRepository.save(user);
+
+        Membership membership1 = new Membership("membership1", 10_000);
+        Membership membership2 = new Membership("membership2", 50_000);
+        Membership membership3 = new Membership("membership3", 8_000);
+        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
+
+        Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
+        Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
+        Subscription subscription3 = new Subscription(user, membership3, ACTIVE);
+        subscriptionRepository.saveAll(List.of(subscription1, subscription2, subscription3));
+
+        // when
+        List<Subscription> oldestSubscriptions = subscriptionRepository.findOldestSubscriptions(user.getId());
+
+        // then
+        assertThat(oldestSubscriptions)
+            .hasSize(3)
+            .extracting(Subscription::getCreatedDate)
+            .isSortedAccordingTo(naturalOrder());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #13 

<br>

## 작업 내용
### 기타
- 어노테이션의 순서를 일관성있게 수정했습니다. (클래스 레벨, 메서드 레벨 순)
- 파일 정리를 위해 패키지를 추가했습니다. (post, subscription)
- 명확성을 위해 `User` 엔티티의 `username` 프로퍼티를 `nickname`으로 수정했습니다.

### 리포지토리
- `UserRepository`, `MembershipRepository`, `SubscriptonRepository`를 구현했습니다.
- `UserRepository`, `SubscriptonRepository`의 커스텀 메서드에 대한 테스트 코드를 작성했습니다.
- 간편한 테스트 코드 작성을 위한 어노테이션 `@DataJpaTestWithAuditing`을 정의했습니다. (DataJpaTest + Auditing 기능)

#### `UserRepository`
- 쿼리 메서드 기능을 사용해 특정 유저를 조회하는 `findUserByNickname(String nickname)` 메서드를 정의했습니다.

#### `MembershipRepository`
- 기본 JpaRepository만 사용합니다. (따라서 테스트는 따로 작성하지 않았습니다.)

#### `SubscriptonRepository`
- Querydsl 사용을 위한 커스텀 리포지토리를 정의했습니다.
- 자신의 구독을 시간 순으로 조회하는 `findNewestSubscriptions`, `findOldestSubscriptions` 메서드를 정의했습니다.

<br>

## 질문
1. 일반적으로 어떤 기준으로 쿼리 메서드, jpql, querydsl을 사용하나요? 개인적으로 쿼리 메서드는 조금만 길어져도 별로같고, jpql을 사용하는 것보다 차라리 querydsl을 사용해 인터페이스를 분리하는게 더 깔끔한 방식 같은데 어떻게 생각하시나요??
2. `CustomSubscriptionRepositoryImpl`에서 어차피 항상 active한 구독을 가져오므로 따로 메서드 명에서 드러내거나, 인자로 받고 있지는 않는데, 이 부분은 어떻게 생각하시나요?
3. `SubscriptionRepository`와 `CustomSubscriptionRepositoryImpl` 중 어떤 것을 대상으로 테스트 코드를 생성하는게 올바른가요? 저는 일단 메서드가 몇 개 없어서 `SubscriptionRepository`에 대해 작성했는데, best practice가 있을까요?
4. 리포지토리에 대한 테스트 작성할 때, `@DataJpaTest`와 `@SpringbootTest` 중 어떤 어노테이션을 쓰는 게 적합할까요? 저는 `@SpringbootTest`를 사용해도 괜찮다고 생각하는데 어떻게 생각하신는지 궁금합니다!
5. `SubscriptionRepositoryTest`와 같은 경우, fixture 세팅을 위해 set up 메서드를 사용하는게 적절할까요? 나중에 다른 테스트 메서드들이 추가되면 조금씩 다른 데이터를 사용할 것 같아 각각 정의하긴 했습니다... 이것도 어떤 best practice가 있을까요?

<br>

## 노트
- 테스트 코드를 잘 작성했는지와  `CustomSubscriptionRepositoryImpl` 위주로 확인 해주시면 될 것 같습니다 :)
- 피드백 해주시면 반영 후, 게시물 서비스와 관련된 리포지토리들을 구현할 예정입니다.