### PR TITLE
유저 서비스 리포지토리 리팩토링

### DIFF
--- a/src/main/java/com/stemm/pubsub/service/post/entity/Comment.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/Comment.java
@@ -34,9 +34,9 @@ public class Comment extends BaseEntity {
     private String content;
 
     @Column(nullable = false)
-    private Long likeCount;
+    private int likeCount;
 
-    public Comment(Post post, User user, String content, Long likeCount) {
+    public Comment(Post post, User user, String content, int likeCount) {
         this.post = post;
         this.user = user;
         this.content = content;

--- a/src/main/java/com/stemm/pubsub/service/post/entity/post/Post.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/post/Post.java
@@ -32,7 +32,7 @@ public class Post extends BaseEntity {
     private String imageUrl;
 
     @Enumerated(STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 10)
     private Visibility visibility;
 
     public Post(User user, String content, String imageUrl, Visibility visibility) {

--- a/src/main/java/com/stemm/pubsub/service/post/entity/post/PostLike.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/post/PostLike.java
@@ -29,7 +29,7 @@ public class PostLike extends BaseEntity {
     private User user;
 
     @Enumerated(STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 10)
     private LikeStatus status;
 
     public PostLike(Post post, User user, LikeStatus status) {

--- a/src/main/java/com/stemm/pubsub/service/user/entity/Membership.java
+++ b/src/main/java/com/stemm/pubsub/service/user/entity/Membership.java
@@ -20,7 +20,7 @@ public class Membership extends BaseEntity {
     @Column(name = "membership_id")
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String name;
 
     @Column(nullable = false)

--- a/src/main/java/com/stemm/pubsub/service/user/entity/User.java
+++ b/src/main/java/com/stemm/pubsub/service/user/entity/User.java
@@ -27,7 +27,7 @@ public class User extends BaseEntity {
     @JoinColumn(name = "membership_id")
     private Membership membership;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false, unique = true, length = 100)
     private String nickname;
 
     @Column(nullable = false)

--- a/src/main/java/com/stemm/pubsub/service/user/entity/subscription/Subscription.java
+++ b/src/main/java/com/stemm/pubsub/service/user/entity/subscription/Subscription.java
@@ -31,7 +31,7 @@ public class Subscription extends BaseEntity {
     private Membership membership;
 
     @Enumerated(STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private SubscriptionStatus status;
 
     public Subscription(User user, Membership membership, SubscriptionStatus status) {

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionRepository.java
@@ -3,5 +3,7 @@ package com.stemm.pubsub.service.user.repository.subscription;
 import com.stemm.pubsub.service.user.entity.subscription.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SubscriptionRepository extends JpaRepository<Subscription, Long>, CustomSubscriptionRepository {
+public interface SubscriptionRepository extends
+    JpaRepository<Subscription, Long>,
+    SubscriptionTimeBasedQueryRepository {
 }

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepository.java
@@ -4,7 +4,7 @@ import com.stemm.pubsub.service.user.entity.subscription.Subscription;
 
 import java.util.List;
 
-public interface CustomSubscriptionRepository {
+public interface SubscriptionTimeBasedQueryRepository {
     List<Subscription> findNewestSubscriptions(Long userId);
     List<Subscription> findOldestSubscriptions(Long userId);
 }

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImpl.java
@@ -10,11 +10,11 @@ import java.util.List;
 import static com.stemm.pubsub.service.user.entity.subscription.QSubscription.subscription;
 import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
 
-public class CustomSubscriptionRepositoryImpl implements CustomSubscriptionRepository {
+public class SubscriptionTimeBasedQueryRepositoryImpl implements SubscriptionTimeBasedQueryRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public CustomSubscriptionRepositoryImpl(EntityManager entityManager) {
+    public SubscriptionTimeBasedQueryRepositoryImpl(EntityManager entityManager) {
         queryFactory = new JPAQueryFactory(entityManager);
     }
 

--- a/src/test/java/com/stemm/pubsub/common/DataJpaTestWithAuditing.java
+++ b/src/test/java/com/stemm/pubsub/common/DataJpaTestWithAuditing.java
@@ -1,4 +1,4 @@
-package com.stemm.pubsub.common.utils;
+package com.stemm.pubsub.common;
 
 import com.stemm.pubsub.common.config.JpaAuditingConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
@@ -1,0 +1,5 @@
+package com.stemm.pubsub.common;
+
+@DataJpaTestWithAuditing
+public abstract class RepositoryTestSupport {
+}

--- a/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
@@ -1,5 +1,18 @@
 package com.stemm.pubsub.common;
 
+import com.stemm.pubsub.service.user.repository.MembershipRepository;
+import com.stemm.pubsub.service.user.repository.UserRepository;
+import com.stemm.pubsub.service.user.repository.subscription.SubscriptionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
 @DataJpaTestWithAuditing
 public abstract class RepositoryTestSupport {
+    @Autowired
+    protected UserRepository userRepository;
+
+    @Autowired
+    protected MembershipRepository membershipRepository;
+
+    @Autowired
+    protected SubscriptionRepository subscriptionRepository;
 }

--- a/src/test/java/com/stemm/pubsub/service/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/UserRepositoryTest.java
@@ -4,16 +4,12 @@ import com.stemm.pubsub.common.RepositoryTestSupport;
 import com.stemm.pubsub.service.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class UserRepositoryTest extends RepositoryTestSupport {
-
-    @Autowired
-    private UserRepository userRepository;
 
     @Test
     @DisplayName("닉네임으로 유저를 조회합니다.")

--- a/src/test/java/com/stemm/pubsub/service/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/UserRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.stemm.pubsub.service.user.repository;
 
-import com.stemm.pubsub.common.utils.DataJpaTestWithAuditing;
+import com.stemm.pubsub.common.RepositoryTestSupport;
 import com.stemm.pubsub.service.user.entity.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,8 +10,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTestWithAuditing
-class UserRepositoryTest {
+class UserRepositoryTest extends RepositoryTestSupport {
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
@@ -1,6 +1,6 @@
 package com.stemm.pubsub.service.user.repository.subscription;
 
-import com.stemm.pubsub.common.utils.DataJpaTestWithAuditing;
+import com.stemm.pubsub.common.RepositoryTestSupport;
 import com.stemm.pubsub.service.user.entity.Membership;
 import com.stemm.pubsub.service.user.entity.User;
 import com.stemm.pubsub.service.user.entity.subscription.Subscription;
@@ -17,8 +17,7 @@ import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.reverseOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DataJpaTestWithAuditing
-class SubscriptionTimeBasedQueryRepositoryImplTest {
+class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport {
 
     @Autowired
     private UserRepository userRepository;

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
@@ -4,11 +4,8 @@ import com.stemm.pubsub.common.RepositoryTestSupport;
 import com.stemm.pubsub.service.user.entity.Membership;
 import com.stemm.pubsub.service.user.entity.User;
 import com.stemm.pubsub.service.user.entity.subscription.Subscription;
-import com.stemm.pubsub.service.user.repository.MembershipRepository;
-import com.stemm.pubsub.service.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 
@@ -18,15 +15,6 @@ import static java.util.Comparator.reverseOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport {
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private MembershipRepository membershipRepository;
-
-    @Autowired
-    private SubscriptionRepository subscriptionRepository;
 
     @Test
     @DisplayName("유저가 구독한 멤버십을 최신 순으로 조회합니다.")

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
@@ -4,6 +4,7 @@ import com.stemm.pubsub.common.RepositoryTestSupport;
 import com.stemm.pubsub.service.user.entity.Membership;
 import com.stemm.pubsub.service.user.entity.User;
 import com.stemm.pubsub.service.user.entity.subscription.Subscription;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,22 +17,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport {
 
+    private User user;
+    private Membership membership1;
+    private Membership membership2;
+    private Membership membership3;
+
+    @BeforeEach
+    void setUp() {
+        user = createUser();
+        userRepository.save(user);
+
+        membership1 = new Membership("membership1", 10_000);
+        membership2 = new Membership("membership2", 50_000);
+        membership3 = new Membership("membership3", 8_000);
+        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
+    }
+
     @Test
     @DisplayName("유저가 구독한 멤버십을 최신 순으로 조회합니다.")
     void findNewestSubscriptions() {
         // given
-        User user = User.builder()
-            .nickname("a")
-            .name("user")
-            .email("a@me.com")
-            .build();
-        userRepository.save(user);
-
-        Membership membership1 = new Membership("membership1", 10_000);
-        Membership membership2 = new Membership("membership2", 50_000);
-        Membership membership3 = new Membership("membership3", 8_000);
-        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
-
         Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
         Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
         Subscription subscription3 = new Subscription(user, membership3, ACTIVE);
@@ -51,18 +56,6 @@ class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport
     @DisplayName("유저가 구독한 멤버십을 오래된 순으로 조회합니다.")
     void findOldestSubscriptions() {
         // given
-        User user = User.builder()
-            .nickname("a")
-            .name("user")
-            .email("a@me.com")
-            .build();
-        userRepository.save(user);
-
-        Membership membership1 = new Membership("membership1", 10_000);
-        Membership membership2 = new Membership("membership2", 50_000);
-        Membership membership3 = new Membership("membership3", 8_000);
-        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
-
         Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
         Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
         Subscription subscription3 = new Subscription(user, membership3, ACTIVE);
@@ -76,5 +69,13 @@ class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport
             .hasSize(3)
             .extracting(Subscription::getCreatedDate)
             .isSortedAccordingTo(naturalOrder());
+    }
+
+    private User createUser() {
+        return User.builder()
+            .nickname("a")
+            .name("user")
+            .email("a@me.com")
+            .build();
     }
 }

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
@@ -18,7 +18,7 @@ import static java.util.Comparator.reverseOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTestWithAuditing
-class SubscriptionRepositoryTest {
+class SubscriptionTimeBasedQueryRepositoryImplTest {
 
     @Autowired
     private UserRepository userRepository;


### PR DESCRIPTION
## 관련 이슈
- #10
- #13 

<br>

## 작업 내용
### 엔티티 수정
- 엔티티에 length 조건을 추가했습니다.

### 인터페이스 수정
- 명확성을 위해 인터페이스 명을 `CustomSubscriptionRepository`에서 `SubscriptionTimeBasedQueryRepository`로 수정했습니다.
  - 해당 인터페이스는 구독 목록을 시간 순으로 불러오기 위한 인터페이스이며, 다른 쿼리가 필요하면 다른 인터페이스를 정의할 예정입니다.
  
### 테스트 코드
- 서버가 올라가는 횟수를 줄이고자 테스트 환경을 통합했습니다. (계층 별 테스트 환경 통합 예정)
- `SubscriptionTimeBasedQueryRepositoryImpl`에 대한 테스트를 작성했습니다.

<br>

## 노트
- 바꾼 네이밍이 적절한지, `SubscriptionTimeBasedQueryRepositoryImplTest` 처럼 테스트 작성하는 것은 기존에 비해 어떤지 피드백 해주시면 감사하겠습니다!