### PR TITLE
구독한 멤버십에 대한 n+1 문제 해결

### DIFF
--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImpl.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityManager;
 
 import java.util.List;
 
+import static com.stemm.pubsub.service.user.entity.QMembership.membership;
 import static com.stemm.pubsub.service.user.entity.subscription.QSubscription.subscription;
 import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
 
@@ -22,6 +23,7 @@ public class SubscriptionTimeBasedQueryRepositoryImpl implements SubscriptionTim
     public List<Subscription> findNewestSubscriptions(Long userId) {
         return queryFactory
             .selectFrom(subscription)
+            .join(subscription.membership, membership)
             .where(userIdEquals(userId), isActive())
             .orderBy(subscription.createdDate.desc())
             .fetch();
@@ -31,6 +33,7 @@ public class SubscriptionTimeBasedQueryRepositoryImpl implements SubscriptionTim
     public List<Subscription> findOldestSubscriptions(Long userId) {
         return queryFactory
             .selectFrom(subscription)
+            .join(subscription.membership, membership)
             .where(userIdEquals(userId), isActive())
             .orderBy(subscription.createdDate.asc())
             .fetch();

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImpl.java
@@ -23,7 +23,7 @@ public class SubscriptionTimeBasedQueryRepositoryImpl implements SubscriptionTim
     public List<Subscription> findNewestSubscriptions(Long userId) {
         return queryFactory
             .selectFrom(subscription)
-            .join(subscription.membership, membership)
+            .join(subscription.membership, membership).fetchJoin()
             .where(userIdEquals(userId), isActive())
             .orderBy(subscription.createdDate.desc())
             .fetch();
@@ -33,7 +33,7 @@ public class SubscriptionTimeBasedQueryRepositoryImpl implements SubscriptionTim
     public List<Subscription> findOldestSubscriptions(Long userId) {
         return queryFactory
             .selectFrom(subscription)
-            .join(subscription.membership, membership)
+            .join(subscription.membership, membership).fetchJoin()
             .where(userIdEquals(userId), isActive())
             .orderBy(subscription.createdDate.asc())
             .fetch();

--- a/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
@@ -4,9 +4,13 @@ import com.stemm.pubsub.service.user.repository.MembershipRepository;
 import com.stemm.pubsub.service.user.repository.UserRepository;
 import com.stemm.pubsub.service.user.repository.subscription.SubscriptionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 @DataJpaTestWithAuditing
 public abstract class RepositoryTestSupport {
+    @Autowired
+    protected TestEntityManager entityManager;
+
     @Autowired
     protected UserRepository userRepository;
 

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
@@ -11,32 +11,27 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
-import static java.util.Comparator.naturalOrder;
-import static java.util.Comparator.reverseOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport {
 
     private User user;
-    private Membership membership1;
-    private Membership membership2;
-    private Membership membership3;
 
     @BeforeEach
     void setUp() {
         user = createUser();
         userRepository.save(user);
-
-        membership1 = new Membership("membership1", 10_000);
-        membership2 = new Membership("membership2", 50_000);
-        membership3 = new Membership("membership3", 8_000);
-        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
     }
 
     @Test
     @DisplayName("유저가 구독한 멤버십을 최신 순으로 조회합니다.")
     void findNewestSubscriptions() {
         // given
+        Membership membership1 = new Membership("membership1", 10_000);
+        Membership membership2 = new Membership("membership2", 50_000);
+        Membership membership3 = new Membership("membership3", 8_000);
+        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
+
         Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
         Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
         Subscription subscription3 = new Subscription(user, membership3, ACTIVE);
@@ -48,14 +43,20 @@ class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport
         // then
         assertThat(newestSubscriptions)
             .hasSize(3)
-            .extracting(Subscription::getCreatedDate)
-            .isSortedAccordingTo(reverseOrder());
+            .extracting(Subscription::getMembership)
+            .extracting(Membership::getName)
+            .containsExactly("membership3", "membership2", "membership1");
     }
 
     @Test
     @DisplayName("유저가 구독한 멤버십을 오래된 순으로 조회합니다.")
     void findOldestSubscriptions() {
         // given
+        Membership membership1 = new Membership("membership1", 10_000);
+        Membership membership2 = new Membership("membership2", 50_000);
+        Membership membership3 = new Membership("membership3", 8_000);
+        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
+
         Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
         Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
         Subscription subscription3 = new Subscription(user, membership3, ACTIVE);
@@ -67,8 +68,9 @@ class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport
         // then
         assertThat(oldestSubscriptions)
             .hasSize(3)
-            .extracting(Subscription::getCreatedDate)
-            .isSortedAccordingTo(naturalOrder());
+            .extracting(Subscription::getMembership)
+            .extracting(Membership::getName)
+            .containsExactly("membership1", "membership2", "membership3");
     }
 
     private User createUser() {

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeBasedQueryRepositoryImplTest.java
@@ -16,22 +16,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport {
 
     private User user;
+    private Membership membership1;
+    private Membership membership2;
+    private Membership membership3;
 
     @BeforeEach
     void setUp() {
         user = createUser();
         userRepository.save(user);
+
+        membership1 = new Membership("membership1", 10_000);
+        membership2 = new Membership("membership2", 50_000);
+        membership3 = new Membership("membership3", 8_000);
+        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
     }
 
     @Test
     @DisplayName("유저가 구독한 멤버십을 최신 순으로 조회합니다.")
     void findNewestSubscriptions() {
         // given
-        Membership membership1 = new Membership("membership1", 10_000);
-        Membership membership2 = new Membership("membership2", 50_000);
-        Membership membership3 = new Membership("membership3", 8_000);
-        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
-
         Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
         Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
         Subscription subscription3 = new Subscription(user, membership3, ACTIVE);
@@ -52,11 +55,6 @@ class SubscriptionTimeBasedQueryRepositoryImplTest extends RepositoryTestSupport
     @DisplayName("유저가 구독한 멤버십을 오래된 순으로 조회합니다.")
     void findOldestSubscriptions() {
         // given
-        Membership membership1 = new Membership("membership1", 10_000);
-        Membership membership2 = new Membership("membership2", 50_000);
-        Membership membership3 = new Membership("membership3", 8_000);
-        membershipRepository.saveAll(List.of(membership1, membership2, membership3));
-
         Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
         Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
         Subscription subscription3 = new Subscription(user, membership3, ACTIVE);


### PR DESCRIPTION
## 관련 이슈
- #13

<br>

## 작업 내용
- 유저가 구독한 멤버십을 조회하면서 n+1 문제가 발생했습니다.
- 멤버십은 구독과 항상 같이 조회되므로 fetch join을 사용하여 해결했습니다.
- 또한, 테스트의 then 절을 멤버십을 체크하도록 수정했습니다. (기존 테스트는 구독을 불러왔는지 체크)

<br>

## 노트
- 영속성 컨텍스트의 1차 캐시 때문에 쿼리를 확인하기 어려운 경우, clear를 테스트 메서드마다 명시적으로 해줘야하나요? (테스트 fixture를 저장하는 과정에서 이들이 모두 1차 캐시에 올라가버려 n+1 문제가 발생하는지 몰랐음)