### PR TITLE
구독 중인 멤버십 생성한 유저 Id 조회하는 리포지토리 구현

### DIFF
--- a/src/main/java/com/stemm/pubsub/common/config/QuerydslConfig.java
+++ b/src/main/java/com/stemm/pubsub/common/config/QuerydslConfig.java
@@ -1,0 +1,14 @@
+package com.stemm.pubsub.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @Bean
+    JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/post/entity/Comment.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/Comment.java
@@ -48,4 +48,24 @@ public class Comment extends BaseEntity {
         this.likeCount = 0;
         this.dislikeCount = 0;
     }
+
+    public void incrementLikeCount() {
+        likeCount++;
+    }
+
+    public void decrementLikeCount() {
+        if (likeCount > 0) {
+            likeCount--;
+        }
+    }
+
+    public void incrementDislikeCount() {
+        dislikeCount++;
+    }
+
+    public void decrementDislikeCount() {
+        if (dislikeCount > 0) {
+            dislikeCount--;
+        }
+    }
 }

--- a/src/main/java/com/stemm/pubsub/service/post/entity/post/Post.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/post/Post.java
@@ -1,16 +1,11 @@
 package com.stemm.pubsub.service.post.entity.post;
 
 import com.stemm.pubsub.common.BaseEntity;
-import com.stemm.pubsub.service.post.entity.Comment;
 import com.stemm.pubsub.service.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import static jakarta.persistence.CascadeType.ALL;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -40,32 +35,10 @@ public class Post extends BaseEntity {
     @Column(nullable = false, length = 10)
     private Visibility visibility;
 
-    @OneToMany(mappedBy = "post", cascade = ALL, orphanRemoval = true)
-    private List<PostLike> likes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "post", cascade = ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
-
     public Post(User user, String content, String imageUrl, Visibility visibility) {
         this.user = user;
         this.content = content;
         this.imageUrl = imageUrl;
         this.visibility = visibility;
-    }
-
-    public void addLike(PostLike postLike) {
-        likes.add(postLike);
-
-        if (postLike.getPost() != this) {
-            postLike.setPost(this);
-        }
-    }
-
-    public void addComment(Comment comment) {
-        comments.add(comment);
-
-        if (comment.getPost() != this) {
-            comment.setPost(this);
-        }
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/post/repository/comment/CommentDto.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/comment/CommentDto.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 public record CommentDto(
     Long id,
-    Long postId,
     String nickname,
     String profileImageUrl,
     String content,

--- a/src/main/java/com/stemm/pubsub/service/post/repository/comment/CommentPostRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/comment/CommentPostRepository.java
@@ -1,0 +1,11 @@
+package com.stemm.pubsub.service.post.repository.comment;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CommentPostRepository {
+    /**
+     * 특정 게시물의 댓글을 좋아요 개수 순으로 조회합니다.
+     */
+    Page<CommentDto> findCommentsForPost(Long postId, Pageable pageable);
+}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/comment/CommentPostRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/comment/CommentPostRepositoryImpl.java
@@ -1,0 +1,50 @@
+package com.stemm.pubsub.service.post.repository.comment;
+
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.querydsl.core.types.Projections.constructor;
+import static com.stemm.pubsub.service.post.entity.QComment.comment;
+import static org.springframework.data.support.PageableExecutionUtils.getPage;
+
+@RequiredArgsConstructor
+public class CommentPostRepositoryImpl implements CommentPostRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<CommentDto> findCommentsForPost(Long postId, Pageable pageable) {
+        List<CommentDto> content = queryFactory
+            .select(
+                constructor(
+                    CommentDto.class,
+                    comment.id,
+                    comment.user.nickname,
+                    comment.user.profileImageUrl,
+                    comment.content,
+                    comment.likeCount,
+                    comment.dislikeCount,
+                    comment.createdDate,
+                    comment.lastModifiedDate
+                )
+            )
+            .from(comment)
+            .where(comment.post.id.eq(postId))
+            .orderBy(comment.likeCount.desc(), comment.createdDate.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(comment.count())
+            .from(comment)
+            .where(comment.post.id.eq(postId));
+
+        return getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/comment/CommentRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/comment/CommentRepository.java
@@ -3,5 +3,5 @@ package com.stemm.pubsub.service.post.repository.comment;
 import com.stemm.pubsub.service.post.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CommentRepository extends JpaRepository<Comment, Long> {
+public interface CommentRepository extends JpaRepository<Comment, Long>, CommentPostRepository {
 }

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepository.java
@@ -3,11 +3,16 @@ package com.stemm.pubsub.service.post.repository.post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface PostVisibilityRepository {
     /**
      * `PUBLIC` 게시물을 최신 순으로 조회합니다.
      */
     Page<PostDto> findPublicPosts(Pageable pageable);
 
-    // TODO: 다른 메서드 추가 예정
+    /**
+     * 특정 유저들의 `PRIVATE` 게시물을 최신 순으로 조회합니다.
+     */
+    Page<PostDto> findUsersPrivatePosts(List<Long> userIds, Pageable pageable);
 }

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionRepository.java
@@ -3,5 +3,8 @@ package com.stemm.pubsub.service.user.repository.subscription;
 import com.stemm.pubsub.service.user.entity.subscription.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SubscriptionRepository extends JpaRepository<Subscription, Long>, SubscriptionTimeRepository {
+public interface SubscriptionRepository extends
+    JpaRepository<Subscription, Long>,
+    SubscriptionTimeRepository,
+    SubscriptionUserRepository {
 }

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeRepositoryImpl.java
@@ -3,20 +3,17 @@ package com.stemm.pubsub.service.user.repository.subscription;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.stemm.pubsub.service.user.entity.subscription.Subscription;
-import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
 import static com.stemm.pubsub.service.user.entity.subscription.QSubscription.subscription;
 import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
 
+@RequiredArgsConstructor
 public class SubscriptionTimeRepositoryImpl implements SubscriptionTimeRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    public SubscriptionTimeRepositoryImpl(EntityManager entityManager) {
-        queryFactory = new JPAQueryFactory(entityManager);
-    }
 
     @Override
     public List<Subscription> findNewestSubscriptions(Long userId) {

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepository.java
@@ -1,0 +1,10 @@
+package com.stemm.pubsub.service.user.repository.subscription;
+
+import com.stemm.pubsub.service.user.repository.subscription.dto.SubscriptionUserDto;
+
+public interface SubscriptionUserRepository {
+    /**
+     * 구독 중인 멤버십을 생성한 유저의 Id를 조회합니다.
+     */
+    SubscriptionUserDto findSubscribingUsersId(Long subscriberId);
+}

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.stemm.pubsub.service.user.repository.subscription;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.stemm.pubsub.service.user.repository.subscription.dto.SubscriptionUserDto;
+import jakarta.persistence.EntityManager;
+
+import java.util.List;
+
+import static com.stemm.pubsub.service.user.entity.QUser.user;
+import static com.stemm.pubsub.service.user.entity.subscription.QSubscription.subscription;
+import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
+
+public class SubscriptionUserRepositoryImpl implements SubscriptionUserRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public SubscriptionUserRepositoryImpl(EntityManager entityManager) {
+        queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public SubscriptionUserDto findSubscribingUsersId(Long subscriberId) {
+        List<Long> userIds = queryFactory
+            .select(user.id)
+            .from(subscription)
+            .join(user).on(subscription.membership.id.eq(user.membership.id))
+            .where(subscription.user.id.eq(subscriberId), subscription.status.eq(ACTIVE))
+            .fetch();
+
+        return new SubscriptionUserDto(userIds);
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.stemm.pubsub.service.user.repository.subscription;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.stemm.pubsub.service.user.repository.subscription.dto.SubscriptionUserDto;
-import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
@@ -10,13 +10,10 @@ import static com.stemm.pubsub.service.user.entity.QUser.user;
 import static com.stemm.pubsub.service.user.entity.subscription.QSubscription.subscription;
 import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
 
+@RequiredArgsConstructor
 public class SubscriptionUserRepositoryImpl implements SubscriptionUserRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    public SubscriptionUserRepositoryImpl(EntityManager entityManager) {
-        queryFactory = new JPAQueryFactory(entityManager);
-    }
 
     @Override
     public SubscriptionUserDto findSubscribingUsersId(Long subscriberId) {

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/dto/SubscriptionUserDto.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/dto/SubscriptionUserDto.java
@@ -1,0 +1,6 @@
+package com.stemm.pubsub.service.user.repository.subscription.dto;
+
+import java.util.List;
+
+public record SubscriptionUserDto(List<Long> userIds) {
+}

--- a/src/main/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepository.java
@@ -1,6 +1,6 @@
 package com.stemm.pubsub.service.user.repository.user;
 
 public interface UserInfoRepository {
-    UserDto findByUserId(Long userId);
-    UserDto findByNickname(String nickname);
+    UserDto findUserById(Long userId);
+    UserDto findUserByNickname(String nickname);
 }

--- a/src/main/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImpl.java
@@ -15,7 +15,7 @@ public class UserInfoRepositoryImpl implements UserInfoRepository {
     }
 
     @Override
-    public UserDto findByUserId(Long userId) {
+    public UserDto findUserById(Long userId) {
         return queryFactory
             .select(
                 constructor(
@@ -34,7 +34,7 @@ public class UserInfoRepositoryImpl implements UserInfoRepository {
     }
 
     @Override
-    public UserDto findByNickname(String nickname) {
+    public UserDto findUserByNickname(String nickname) {
         return queryFactory
             .select(
                 constructor(

--- a/src/main/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImpl.java
@@ -1,18 +1,15 @@
 package com.stemm.pubsub.service.user.repository.user;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
 
 import static com.querydsl.core.types.Projections.constructor;
 import static com.stemm.pubsub.service.user.entity.QUser.user;
 
+@RequiredArgsConstructor
 public class UserInfoRepositoryImpl implements UserInfoRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    public UserInfoRepositoryImpl(EntityManager entityManager) {
-        queryFactory = new JPAQueryFactory(entityManager);
-    }
 
     @Override
     public UserDto findByUserId(Long userId) {

--- a/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
@@ -2,6 +2,7 @@ package com.stemm.pubsub.common;
 
 import com.stemm.pubsub.common.config.QuerydslConfig;
 import com.stemm.pubsub.service.post.repository.PostLikeRepository;
+import com.stemm.pubsub.service.post.repository.comment.CommentRepository;
 import com.stemm.pubsub.service.post.repository.post.PostRepository;
 import com.stemm.pubsub.service.user.repository.membership.MembershipRepository;
 import com.stemm.pubsub.service.user.repository.subscription.SubscriptionRepository;
@@ -30,4 +31,7 @@ public abstract class RepositoryTestSupport {
 
     @Autowired
     protected PostLikeRepository postLikeRepository;
+
+    @Autowired
+    protected CommentRepository commentRepository;
 }

--- a/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
@@ -1,5 +1,6 @@
 package com.stemm.pubsub.common;
 
+import com.stemm.pubsub.common.config.QuerydslConfig;
 import com.stemm.pubsub.service.post.repository.PostLikeRepository;
 import com.stemm.pubsub.service.post.repository.post.PostRepository;
 import com.stemm.pubsub.service.user.repository.membership.MembershipRepository;
@@ -7,8 +8,10 @@ import com.stemm.pubsub.service.user.repository.subscription.SubscriptionReposit
 import com.stemm.pubsub.service.user.repository.user.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
 
 @DataJpaTestWithAuditing
+@Import(QuerydslConfig.class)
 public abstract class RepositoryTestSupport {
     @Autowired
     protected TestEntityManager entityManager;

--- a/src/test/java/com/stemm/pubsub/service/post/repository/comment/CommentPostRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/repository/comment/CommentPostRepositoryImplTest.java
@@ -1,0 +1,54 @@
+package com.stemm.pubsub.service.post.repository.comment;
+
+import com.stemm.pubsub.common.RepositoryTestSupport;
+import com.stemm.pubsub.service.post.entity.Comment;
+import com.stemm.pubsub.service.post.entity.post.Post;
+import com.stemm.pubsub.service.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.List;
+
+import static com.stemm.pubsub.service.post.entity.post.Visibility.PUBLIC;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CommentPostRepositoryImplTest extends RepositoryTestSupport {
+
+    @Test
+    @DisplayName("특정 게시물의 댓글을 좋아요 순으로 조회합니다.")
+    void findCommentsForPost() {
+        // given
+        User user = createUser();
+        userRepository.save(user);
+
+        Post post = new Post(user, "content1", null, PUBLIC);
+        postRepository.save(post);
+
+        Comment comment1 = new Comment(post, user, "comment1");
+        Comment comment2 = new Comment(post, user, "comment2");
+        Comment comment3 = new Comment(post, user, "comment3");
+        commentRepository.saveAll(List.of(comment1, comment2, comment3));
+
+        // when
+        Page<CommentDto> comments = commentRepository.findCommentsForPost(
+            post.getId(),
+            PageRequest.of(0, 10)
+        );
+
+        // then
+        assertThat(comments)
+            .hasSize(3)
+            .extracting("content")
+            .containsExactly(comment3.getContent(), comment2.getContent(), comment1.getContent());
+    }
+
+    private User createUser() {
+        return User.builder()
+            .nickname("nickname")
+            .name("name")
+            .email("user@me.com")
+            .build();
+    }
+}

--- a/src/test/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImplTest.java
@@ -2,68 +2,79 @@ package com.stemm.pubsub.service.post.repository.post;
 
 import com.stemm.pubsub.common.RepositoryTestSupport;
 import com.stemm.pubsub.service.post.entity.post.Post;
-import com.stemm.pubsub.service.post.entity.post.PostLike;
 import com.stemm.pubsub.service.user.entity.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
-import static com.stemm.pubsub.service.post.entity.post.LikeStatus.DISLIKE;
-import static com.stemm.pubsub.service.post.entity.post.LikeStatus.LIKE;
 import static com.stemm.pubsub.service.post.entity.post.Visibility.PRIVATE;
 import static com.stemm.pubsub.service.post.entity.post.Visibility.PUBLIC;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.groups.Tuple.tuple;
 
 class PostVisibilityRepositoryImplTest extends RepositoryTestSupport {
 
+    User user1;
+    User user2;
+    User user3;
+
     @BeforeEach
     void setUp() {
-        User user1 = createUser("user1", "name1", "user1@email.com");
-        User user2 = createUser("user2", "name2", "user2@email.com");
-        User user3 = createUser("user3", "name3", "user3@email.com");
-        User user4 = createUser("user4", "name4", "user4@email.com");
-        userRepository.saveAll(List.of(user1, user2, user3, user4));
-
-        Post post1 = new Post(user1, "content1", null, PUBLIC);
-        Post post2 = new Post(user1, "content2", null, PRIVATE);
-        Post post3 = new Post(user2, "content3", null, PUBLIC);
-        Post post4 = new Post(user3, "content4", null, PRIVATE);
-        Post post5 = new Post(user3, "content5", null, PUBLIC);
-        post1.addLike(new PostLike(post1, user1, LIKE));
-        post1.addLike(new PostLike(post1, user2, LIKE));
-        post1.addLike(new PostLike(post1, user3, DISLIKE));
-        post2.addLike(new PostLike(post2, user1, LIKE));
-        post2.addLike(new PostLike(post2, user3, DISLIKE));
-        post3.addLike(new PostLike(post3, user1, LIKE));
-        post4.addLike(new PostLike(post4, user1, DISLIKE));
-        postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+        user1 = createUser("user1", "name1", "user1@email.com");
+        user2 = createUser("user2", "name2", "user2@email.com");
+        user3 = createUser("user3", "name3", "user3@email.com");
+        userRepository.saveAll(List.of(user1, user2, user3));
     }
 
     @Test
     @DisplayName("`PUBLIC` 게시물을 최신 순으로 조회합니다.")
     void findPublicPosts() {
         // given
-        Pageable pageable = PageRequest.of(0, 10);
+        Post post1 = new Post(user1, "content1", null, PUBLIC);
+        Post post2 = new Post(user1, "content2", null, PUBLIC);
+        Post post3 = new Post(user2, "content3", null, PUBLIC);
+        Post post4 = new Post(user3, "content4", null, PRIVATE);
+        Post post5 = new Post(user3, "content5", null, PUBLIC);
+        postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+
         entityManager.clear();
 
         // when
-        Page<PostDto> posts = postRepository.findPublicPosts(pageable);
+        Page<PostDto> posts = postRepository.findPublicPosts(PageRequest.of(0, 10));
+
+        // then
+        assertThat(posts)
+            .hasSize(4)
+            .extracting("id")
+            .containsExactly(post5.getId(), post3.getId(), post2.getId(), post1.getId());
+    }
+
+    @Test
+    @DisplayName("특정 유저들의 `PRIVATE` 게시물을 최신 순으로 조회합니다.")
+    void findUsersPrivatePosts() {
+        // given
+        Post post1 = new Post(user1, "content1", null, PUBLIC);
+        Post post2 = new Post(user1, "content2", null, PRIVATE);
+        Post post3 = new Post(user2, "content3", null, PRIVATE);
+        Post post4 = new Post(user3, "content4", null, PRIVATE);
+        Post post5 = new Post(user3, "content5", null, PUBLIC);
+        postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+
+        List<Long> userIds = List.of(user1.getId(), user2.getId(), user3.getId());
+
+        entityManager.clear();
+
+        // when
+        Page<PostDto> posts = postRepository.findUsersPrivatePosts(userIds, PageRequest.of(0, 10));
 
         // then
         assertThat(posts)
             .hasSize(3)
-            .extracting("content", "likeCount", "dislikeCount")
-            .containsExactly(
-                tuple("content5", 0, 0),
-                tuple("content3", 1, 0),
-                tuple("content1", 2, 1)
-            );
+            .extracting("id")
+            .containsExactly(post4.getId(), post3.getId(), post2.getId());
     }
 
     private User createUser(String nickname, String name, String email) {

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImplTest.java
@@ -1,0 +1,59 @@
+package com.stemm.pubsub.service.user.repository.subscription;
+
+import com.stemm.pubsub.common.RepositoryTestSupport;
+import com.stemm.pubsub.service.user.entity.Membership;
+import com.stemm.pubsub.service.user.entity.User;
+import com.stemm.pubsub.service.user.entity.subscription.Subscription;
+import com.stemm.pubsub.service.user.repository.subscription.dto.SubscriptionUserDto;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
+
+class SubscriptionUserRepositoryImplTest extends RepositoryTestSupport {
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+    @Test
+    @DisplayName("구독 중인 멤버십을 생성한 유저의 Id를 조회합니다.")
+    void findSubscribingUsersId() {
+        // given
+        Membership membership1 = new Membership("mem1", 10_000);
+        Membership membership2 = new Membership("mem2", 20_000);
+        membershipRepository.saveAll(List.of(membership1, membership2));
+
+        User user = createUser("user", "name1", "user1@me.com", null);
+        User membershipUser1 = createUser("memUser1", "memName1", "memName1@me.com", membership1);
+        User membershipUser2 = createUser("memUser2", "memName2", "memName2@me.com", membership2);
+        userRepository.saveAll(List.of(user, membershipUser1, membershipUser2));
+
+        Subscription subscription1 = new Subscription(user, membership1, ACTIVE);
+        Subscription subscription2 = new Subscription(user, membership2, ACTIVE);
+        subscriptionRepository.saveAll(List.of(subscription1, subscription2));
+
+        entityManager.clear();
+
+        // when
+        SubscriptionUserDto subscribingUsersId = subscriptionRepository.findSubscribingUsersId(user.getId());
+
+        // then
+        Assertions.assertThat(subscribingUsersId.userIds())
+            .contains(membershipUser1.getId(), membershipUser2.getId());
+    }
+
+    private User createUser(String nickname, String name, String email, Membership membership) {
+        return User.builder()
+            .nickname(nickname)
+            .name(name)
+            .email(email)
+            .membership(membership)
+            .build();
+    }
+}

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImplTest.java
@@ -6,7 +6,6 @@ import com.stemm.pubsub.service.user.entity.User;
 import com.stemm.pubsub.service.user.entity.subscription.Subscription;
 import com.stemm.pubsub.service.user.repository.subscription.dto.SubscriptionUserDto;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,11 +14,6 @@ import java.util.List;
 import static com.stemm.pubsub.service.user.entity.subscription.SubscriptionStatus.ACTIVE;
 
 class SubscriptionUserRepositoryImplTest extends RepositoryTestSupport {
-
-    @BeforeEach
-    void setUp() {
-
-    }
 
     @Test
     @DisplayName("구독 중인 멤버십을 생성한 유저의 Id를 조회합니다.")

--- a/src/test/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImplTest.java
@@ -21,7 +21,7 @@ class UserInfoRepositoryImplTest extends RepositoryTestSupport {
         userRepository.saveAll(List.of(user1, user2, user3));
 
         // when
-        UserDto user = userRepository.findByUserId(1L);
+        UserDto user = userRepository.findUserById(1L);
 
         // then
         assertThat(user)
@@ -39,7 +39,7 @@ class UserInfoRepositoryImplTest extends RepositoryTestSupport {
         userRepository.saveAll(List.of(user1, user2, user3));
 
         // when
-        UserDto user = userRepository.findByNickname(nickname);
+        UserDto user = userRepository.findUserByNickname(nickname);
 
         // then
         assertThat(user)

--- a/src/test/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImplTest.java
@@ -21,29 +21,28 @@ class UserInfoRepositoryImplTest extends RepositoryTestSupport {
         userRepository.saveAll(List.of(user1, user2, user3));
 
         // when
-        UserDto user = userRepository.findByUserId(1L);
+        UserDto user = userRepository.findByUserId(user1.getId());
 
         // then
         assertThat(user)
-            .hasFieldOrPropertyWithValue("id", 1L);
+            .hasFieldOrPropertyWithValue("id", user1.getId());
     }
 
     @Test
     @DisplayName("닉네임으로 유저를 조회합니다.")
     void findUserByNickname() {
         // given
-        String nickname = "user1";
-        User user1 = createUser(nickname, "name1", "user1@email.com");
+        User user1 = createUser("user1", "name1", "user1@email.com");
         User user2 = createUser("user2", "name2", "user2@email.com");
         User user3 = createUser("user3", "name3", "user3@email.com");
         userRepository.saveAll(List.of(user1, user2, user3));
 
         // when
-        UserDto user = userRepository.findByNickname(nickname);
+        UserDto user = userRepository.findByNickname(user1.getNickname());
 
         // then
         assertThat(user)
-            .hasFieldOrPropertyWithValue("nickname", nickname);
+            .hasFieldOrPropertyWithValue("nickname", user1.getNickname());
     }
 
     private User createUser(String nickname, String name, String email) {


### PR DESCRIPTION
## 관련 이슈
- close #13 

<br>

## 작업 내용
- '구독 중인 멤버십을 생성한 유저 Id'를 조회하는 리포지토리 구현 및 테스트 코드 작성했습니다.
- 저번에 피드백 주신 부분을 반영하기 위한 코드입니다.

### 비즈니스 로직 정리
서비스 계층에서 예상되는 흐름입니다. (해당 비즈니스 로직을 위해 총 2번의 쿼리 수행)
1. `findSubscribingUsersId` 호출 -> 구독 중인 멤버십 생성한 유저 Id들 조회
2. 조회한 유저 Id에 해당하는 private post 조회 (페이징)

<br>

## 노트
- (실제 서비스라 가정하면) 홈 화면에서 기본적으로 모든 public 게시물을 보여주고, "구독 중인 유저의 게시물 보기"와 같은 버튼을 누르는 경우에 비즈니스 로직을 실행하는 형태로 하면 좋을 것 같습니다.
- 로직의 개선점이 있다면 피드백 해주시면 감사하겠습니다!