### PR TITLE
특정 유저의 게시물을 조회하는 리포지토리 구현

### DIFF
--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostRepository.java
@@ -3,5 +3,5 @@ package com.stemm.pubsub.service.post.repository.post;
 import com.stemm.pubsub.service.post.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long>, PostVisibilityRepository {
+public interface PostRepository extends JpaRepository<Post, Long>, PostVisibilityRepository, PostUserRepository {
 }

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepository.java
@@ -1,0 +1,9 @@
+package com.stemm.pubsub.service.post.repository.post;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PostUserRepository {
+    Page<PostDto> findPublicPostsByUserId(Long userId, Pageable pageable);
+    Page<PostDto> findPrivatePostsByUserId(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepositoryImpl.java
@@ -1,0 +1,78 @@
+package com.stemm.pubsub.service.post.repository.post;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.stemm.pubsub.service.post.entity.post.Visibility;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.querydsl.core.types.Projections.constructor;
+import static com.stemm.pubsub.service.post.entity.post.LikeStatus.DISLIKE;
+import static com.stemm.pubsub.service.post.entity.post.LikeStatus.LIKE;
+import static com.stemm.pubsub.service.post.entity.post.QPost.post;
+import static com.stemm.pubsub.service.post.entity.post.QPostLike.postLike;
+import static com.stemm.pubsub.service.post.entity.post.Visibility.PRIVATE;
+import static com.stemm.pubsub.service.post.entity.post.Visibility.PUBLIC;
+import static org.springframework.data.support.PageableExecutionUtils.getPage;
+
+@RequiredArgsConstructor
+public class PostUserRepositoryImpl implements PostUserRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final ConstructorExpression<PostDto> postDto = constructor(
+        PostDto.class,
+        post.id,
+        post.user.nickname,
+        post.user.profileImageUrl,
+        post.content,
+        post.imageUrl,
+        postLike.status.when(LIKE).then(1).otherwise(0).sum().intValue().as("likeCount"),
+        postLike.status.when(DISLIKE).then(1).otherwise(0).sum().intValue().as("dislikeCount"),
+        post.createdDate,
+        post.lastModifiedDate
+    );
+
+    @Override
+    public Page<PostDto> findPublicPostsByUserId(Long userId, Pageable pageable) {
+        return getPostDtos(userId, pageable, PUBLIC);
+    }
+
+    @Override
+    public Page<PostDto> findPrivatePostsByUserId(Long userId, Pageable pageable) {
+        return getPostDtos(userId, pageable, PRIVATE);
+    }
+
+    private Page<PostDto> getPostDtos(Long userId, Pageable pageable, Visibility visibility) {
+        List<PostDto> content = queryFactory
+            .select(postDto)
+            .from(post)
+            .leftJoin(postLike).on(post.id.eq(postLike.post.id))
+            .where(userIdEquals(userId), visibilityEquals(visibility))
+            .groupBy(post.id)
+            .orderBy(post.createdDate.desc())
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory
+            .select(post.count())
+            .from(post)
+            .where(userIdEquals(userId), visibilityEquals(visibility));
+
+        return getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression userIdEquals(Long userId) {
+        return post.user.id.eq(userId);
+    }
+
+    private BooleanExpression visibilityEquals(Visibility visibility) {
+        return post.visibility.eq(visibility);
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImpl.java
@@ -25,7 +25,7 @@ public class PostVisibilityRepositoryImpl implements PostVisibilityRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    ConstructorExpression<PostDto> postDto = constructor(
+    private final ConstructorExpression<PostDto> postDto = constructor(
         PostDto.class,
         post.id,
         post.user.nickname,
@@ -44,7 +44,7 @@ public class PostVisibilityRepositoryImpl implements PostVisibilityRepository {
             .select(postDto)
             .from(post)
             .leftJoin(postLike).on(post.id.eq(postLike.post.id))
-            .where(isVisibilityEquals(PUBLIC))
+            .where(visibilityEquals(PUBLIC))
             .groupBy(post.id)
             .orderBy(post.createdDate.desc())
             .offset(pageable.getOffset())
@@ -54,7 +54,7 @@ public class PostVisibilityRepositoryImpl implements PostVisibilityRepository {
         JPAQuery<Long> countQuery = queryFactory
             .select(post.count())
             .from(post)
-            .where(isVisibilityEquals(PUBLIC));
+            .where(visibilityEquals(PUBLIC));
 
         return getPage(content, pageable, countQuery::fetchOne);
     }
@@ -65,7 +65,7 @@ public class PostVisibilityRepositoryImpl implements PostVisibilityRepository {
             .select(postDto)
             .from(post)
             .leftJoin(postLike).on(post.id.eq(postLike.post.id))
-            .where(isUserIdIn(userIds), isVisibilityEquals(PRIVATE))
+            .where(userIdIn(userIds), visibilityEquals(PRIVATE))
             .groupBy(post.id)
             .orderBy(post.createdDate.desc())
             .offset(pageable.getOffset())
@@ -75,16 +75,16 @@ public class PostVisibilityRepositoryImpl implements PostVisibilityRepository {
         JPAQuery<Long> countQuery = queryFactory
             .select(post.count())
             .from(post)
-            .where(isUserIdIn(userIds), isVisibilityEquals(PRIVATE));
+            .where(userIdIn(userIds), visibilityEquals(PRIVATE));
 
         return getPage(content, pageable, countQuery::fetchOne);
     }
 
-    private BooleanExpression isUserIdIn(List<Long> userIds) {
+    private BooleanExpression userIdIn(List<Long> userIds) {
         return post.user.id.in(userIds);
     }
 
-    private BooleanExpression isVisibilityEquals(Visibility visibility) {
+    private BooleanExpression visibilityEquals(Visibility visibility) {
         return post.visibility.eq(visibility);
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepository.java
@@ -6,5 +6,5 @@ public interface SubscriptionUserRepository {
     /**
      * 구독 중인 멤버십을 생성한 유저의 Id를 조회합니다.
      */
-    SubscriptionUserDto findSubscribingUsersId(Long subscriberId);
+    SubscriptionUserDto findSubscribingUserIds(Long subscriberId);
 }

--- a/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImpl.java
@@ -16,7 +16,7 @@ public class SubscriptionUserRepositoryImpl implements SubscriptionUserRepositor
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public SubscriptionUserDto findSubscribingUsersId(Long subscriberId) {
+    public SubscriptionUserDto findSubscribingUserIds(Long subscriberId) {
         List<Long> userIds = queryFactory
             .select(user.id)
             .from(subscription)

--- a/src/main/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.stemm.pubsub.service.user.repository.user;
 
+import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -11,20 +12,20 @@ public class UserInfoRepositoryImpl implements UserInfoRepository {
 
     private final JPAQueryFactory queryFactory;
 
+    private final ConstructorExpression<UserDto> userDto = constructor(
+        UserDto.class,
+        user.id,
+        user.membership.id,
+        user.nickname,
+        user.email,
+        user.profileImageUrl,
+        user.bio
+    );
+
     @Override
     public UserDto findByUserId(Long userId) {
         return queryFactory
-            .select(
-                constructor(
-                    UserDto.class,
-                    user.id,
-                    user.membership.id,
-                    user.nickname,
-                    user.email,
-                    user.profileImageUrl,
-                    user.bio
-                )
-            )
+            .select(userDto)
             .from(user)
             .where(user.id.eq(userId))
             .fetchOne();
@@ -33,17 +34,7 @@ public class UserInfoRepositoryImpl implements UserInfoRepository {
     @Override
     public UserDto findByNickname(String nickname) {
         return queryFactory
-            .select(
-                constructor(
-                    UserDto.class,
-                    user.id,
-                    user.membership.id,
-                    user.nickname,
-                    user.email,
-                    user.profileImageUrl,
-                    user.bio
-                )
-            )
+            .select(userDto)
             .from(user)
             .where(user.nickname.eq(nickname))
             .fetchOne();

--- a/src/test/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImplTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.stemm.pubsub.service.post.entity.post.Visibility.PRIVATE;
@@ -75,6 +76,26 @@ class PostVisibilityRepositoryImplTest extends RepositoryTestSupport {
             .hasSize(3)
             .extracting("id")
             .containsExactly(post4.getId(), post3.getId(), post2.getId());
+    }
+
+    @Test
+    @DisplayName("유저 id가 없는 경우 아무런 게시물도 조회되지 않습니다.")
+    void findNoUsersPrivatePosts() {
+        // given
+        Post post1 = new Post(user1, "content1", null, PUBLIC);
+        Post post2 = new Post(user1, "content2", null, PRIVATE);
+        Post post3 = new Post(user2, "content3", null, PRIVATE);
+        Post post4 = new Post(user3, "content4", null, PRIVATE);
+        Post post5 = new Post(user3, "content5", null, PUBLIC);
+        postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+
+        entityManager.clear();
+
+        // when
+        Page<PostDto> posts = postRepository.findUsersPrivatePosts(new ArrayList<>(), PageRequest.of(0, 10));
+
+        // then
+        assertThat(posts).isEmpty();
     }
 
     private User createUser(String nickname, String name, String email) {

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImplTest.java
@@ -17,7 +17,7 @@ class SubscriptionUserRepositoryImplTest extends RepositoryTestSupport {
 
     @Test
     @DisplayName("구독 중인 멤버십을 생성한 유저의 Id를 조회합니다.")
-    void findSubscribingUsersId() {
+    void findSubscribingUserIds() {
         // given
         Membership membership1 = new Membership("mem1", 10_000);
         Membership membership2 = new Membership("mem2", 20_000);
@@ -35,7 +35,7 @@ class SubscriptionUserRepositoryImplTest extends RepositoryTestSupport {
         entityManager.clear();
 
         // when
-        SubscriptionUserDto subscribingUsersId = subscriptionRepository.findSubscribingUsersId(user.getId());
+        SubscriptionUserDto subscribingUsersId = subscriptionRepository.findSubscribingUserIds(user.getId());
 
         // then
         Assertions.assertThat(subscribingUsersId.userIds())


### PR DESCRIPTION
## 작업 내용
- 특정 유저의 private, public 게시물을 조회하는 `PostUserRepository`를 구현했습니다.
- 특정 유저의 프로필을 조회할 때 사용될것 같습니다.
- 이전 PR의 피드백을 반영했습니다.