### PR TITLE
Spring Security, Jwt 기반 자체 로그인/회원가입 구현

### DIFF
--- a/src/main/java/com/stemm/pubsub/service/auth/AuthController.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/AuthController.java
@@ -4,7 +4,6 @@ import com.stemm.pubsub.service.auth.dto.SignUpRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,10 +20,5 @@ public class AuthController {
     public ResponseEntity<Object> signUp(@Validated @RequestBody SignUpRequest signUpRequest) throws Exception {
         authService.signUp(signUpRequest);
         return ResponseEntity.status(CREATED).build();
-    }
-
-    @GetMapping("/jwt-test")
-    public String jwtTest() {
-        return "token-test 요청 성공";
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/auth/AuthService.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/AuthService.java
@@ -18,7 +18,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public void signUp(SignUpRequest signUpRequest) throws Exception {
+    public void signUp(SignUpRequest signUpRequest) {
         validateSignUp(signUpRequest);
 
         User user = User.builder()
@@ -36,7 +36,7 @@ public class AuthService {
     /**
      * 닉네임, 이메일에 대한 중복 검사를 수행합니다.
      */
-    private void validateSignUp(SignUpRequest signUpRequest) throws Exception {
+    private void validateSignUp(SignUpRequest signUpRequest) {
         if (userRepository.findByNickname(signUpRequest.nickname()).isPresent()) {
             throw new DuplicateValueException("중복되는 닉네임입니다.");
         }

--- a/src/main/java/com/stemm/pubsub/service/auth/AuthService.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/AuthService.java
@@ -17,16 +17,9 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    // TODO: 리턴값?? custom exception 정의 및 메서드 분리
-    // TODO: 중복 체크 매번 db 접근??
     @Transactional
-    public User signUp(SignUpRequest signUpRequest) throws Exception {
-        if (userRepository.findByNickname(signUpRequest.nickname()).isPresent()) {
-            throw new Exception("이미 존재하는 닉네임입니다.");
-        }
-        if (userRepository.findByEmail(signUpRequest.email()).isPresent()) {
-            throw new Exception("이미 존재하는 이메일입니다.");
-        }
+    public void signUp(SignUpRequest signUpRequest) throws Exception {
+        validateSignUp(signUpRequest);
 
         User user = User.builder()
             .nickname(signUpRequest.nickname())
@@ -37,6 +30,19 @@ public class AuthService {
             .role(USER)
             .build();
 
-        return userRepository.save(user);
+        userRepository.save(user);
+    }
+
+    /**
+     * 닉네임, 이메일에 대한 중복 검사를 수행합니다.
+     */
+    private void validateSignUp(SignUpRequest signUpRequest) throws Exception {
+        if (userRepository.findByNickname(signUpRequest.nickname()).isPresent()) {
+            throw new DuplicateValueException("중복되는 닉네임입니다.");
+        }
+
+        if (userRepository.findByEmail(signUpRequest.email()).isPresent()) {
+            throw new DuplicateValueException("중복되는 이메일입니다.");
+        }
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/auth/DuplicateValueException.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/DuplicateValueException.java
@@ -1,0 +1,7 @@
+package com.stemm.pubsub.service.auth;
+
+public class DuplicateValueException extends RuntimeException {
+    public DuplicateValueException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/auth/SecurityConfig.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/SecurityConfig.java
@@ -39,7 +39,6 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
             .authorizeHttpRequests(registry -> registry
-                .requestMatchers("/").permitAll()
                 .requestMatchers("/css/**", "/images/**", "/js/**", "/favicon.ico").permitAll()
                 .requestMatchers("/h2-console/**", "/error").permitAll()
                 .requestMatchers("/login", "/signup").permitAll()
@@ -91,6 +90,6 @@ public class SecurityConfig {
 
     @Bean
     public TokenProcessingFilter tokenProcessingFilter() {
-        return new TokenProcessingFilter(tokenService);
+        return new TokenProcessingFilter(tokenService, customUserDetailsService);
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/auth/SecurityConfig.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.stemm.pubsub.service.auth.config;
+package com.stemm.pubsub.service.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stemm.pubsub.service.auth.handler.LoginFailureHandler;

--- a/src/main/java/com/stemm/pubsub/service/auth/config/SecurityConfig.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/config/SecurityConfig.java
@@ -37,11 +37,11 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
+        return http
             .authorizeHttpRequests(registry -> registry
                 .requestMatchers("/").permitAll()
                 .requestMatchers("/css/**", "/images/**", "/js/**", "/favicon.ico").permitAll()
-                .requestMatchers("/h2-console/**").permitAll()
+                .requestMatchers("/h2-console/**", "/error").permitAll()
                 .requestMatchers("/login", "/signup").permitAll()
                 .anyRequest().authenticated()
             )
@@ -53,9 +53,8 @@ public class SecurityConfig {
             .headers(configurer -> configurer.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
             .sessionManagement(configurer -> configurer.sessionCreationPolicy(STATELESS))
             .addFilterAfter(jsonProcessingFilter(), LogoutFilter.class)
-            .addFilterBefore(tokenProcessingFilter(), JsonProcessingFilter.class);
-
-        return http.build();
+            .addFilterBefore(tokenProcessingFilter(), JsonProcessingFilter.class)
+            .build();
     }
 
     @Bean

--- a/src/main/java/com/stemm/pubsub/service/auth/config/SecurityConfig.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/config/SecurityConfig.java
@@ -4,9 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.stemm.pubsub.service.auth.handler.LoginFailureHandler;
 import com.stemm.pubsub.service.auth.handler.LoginSuccessHandler;
 import com.stemm.pubsub.service.auth.json.JsonProcessingFilter;
-import com.stemm.pubsub.service.auth.oauth.CustomOAuth2UserService;
-import com.stemm.pubsub.service.auth.oauth.OAuth2LoginFailureHandler;
-import com.stemm.pubsub.service.auth.oauth.OAuth2LoginSuccessHandler;
 import com.stemm.pubsub.service.auth.token.TokenProcessingFilter;
 import com.stemm.pubsub.service.auth.token.TokenService;
 import com.stemm.pubsub.service.user.repository.user.UserRepository;
@@ -37,9 +34,6 @@ public class SecurityConfig {
     private final TokenService tokenService;
     private final UserRepository userRepository;
     private final ObjectMapper objectMapper;
-    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
-    private final OAuth2LoginFailureHandler oAuth2LoginFailureHandler;
-    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/stemm/pubsub/service/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/dto/SignUpRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
-    @Size(max = 100, message = "닉네임은 100글자 이하로 설정해주세요.")
+    @Size(max = 100, message = "닉네임은 100자 이하로 설정해주세요.")
     @NotBlank(message = "닉네임을 입력해주세요.")
     String nickname,
 

--- a/src/main/java/com/stemm/pubsub/service/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/dto/SignUpRequest.java
@@ -1,11 +1,11 @@
 package com.stemm.pubsub.service.auth.dto;
 
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record SignUpRequest(
-    @Max(value = 100, message = "닉네임은 100글자 이하로 설정해주세요.")
+    @Size(max = 100, message = "닉네임은 100글자 이하로 설정해주세요.")
     @NotBlank(message = "닉네임을 입력해주세요.")
     String nickname,
 

--- a/src/main/java/com/stemm/pubsub/service/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/dto/SignUpRequest.java
@@ -1,9 +1,11 @@
 package com.stemm.pubsub.service.auth.dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 
 public record SignUpRequest(
+    @Max(value = 100, message = "닉네임은 100글자 이하로 설정해주세요.")
     @NotBlank(message = "닉네임을 입력해주세요.")
     String nickname,
 

--- a/src/main/java/com/stemm/pubsub/service/auth/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/handler/LoginSuccessHandler.java
@@ -24,8 +24,9 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         Authentication authentication
     ) {
         Long userId = extractUserId(authentication);
-        String accessToken = tokenService.createAccessToken(userId);
-        String refreshToken = tokenService.createRefreshToken(userId);
+        String nickname = extractNickname(authentication);
+        String accessToken = tokenService.createAccessToken(userId, nickname);
+        String refreshToken = tokenService.createRefreshToken(userId, nickname);
 
         tokenService.sendAccessTokenAndRefreshToken(response, accessToken, refreshToken);
 
@@ -41,5 +42,10 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private Long extractUserId(Authentication authentication) {
         CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
         return userDetails.getUserId();
+    }
+
+    private String extractNickname(Authentication authentication) {
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getUsername();
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/auth/json/JsonProcessingFilter.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/json/JsonProcessingFilter.java
@@ -18,7 +18,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class JsonProcessingFilter extends AbstractAuthenticationProcessingFilter {
 
-    private static final String LOGIN_URI = "/login";
+    private static final String LOGIN_URI = "/login";  // 해당 uri 요청에만 필터 작동
     private static final String POST = "POST";
     private static final String APPLICATION_JSON = "application/json";
     private static final String USERNAME = "nickname";

--- a/src/main/java/com/stemm/pubsub/service/auth/token/TokenProcessingFilter.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/token/TokenProcessingFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,7 +18,6 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static com.stemm.pubsub.service.user.entity.Role.USER;
-import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -29,9 +29,9 @@ public class TokenProcessingFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(
-        HttpServletRequest request,
-        HttpServletResponse response,
-        FilterChain filterChain
+        @NonNull HttpServletRequest request,
+        @NonNull HttpServletResponse response,
+        @NonNull FilterChain filterChain
     ) throws ServletException, IOException {
         if (isWhitelist(request.getRequestURI())) {
             filterChain.doFilter(request, response);
@@ -57,9 +57,8 @@ public class TokenProcessingFilter extends OncePerRequestFilter {
             return;
         }
 
-        // TODO: 어느 필터에서 request reject 해야하나? (일단 여기서 함)
-//        rejectRequest(response);
-        filterChain.doFilter(request, response);
+        // 토큰 존재하지 않으면 로그인 페이지로 redirect
+        redirectToLogin(response);
     }
 
     private boolean isWhitelist(String requestUri) {
@@ -106,8 +105,7 @@ public class TokenProcessingFilter extends OncePerRequestFilter {
         tokenService.updateRefreshToken(userId, reissuedRefreshToken);
     }
 
-    private void rejectRequest(HttpServletResponse response) throws IOException {
-        log.info("토큰을 확인해주세요.");
-        response.sendError(SC_UNAUTHORIZED, "토큰을 확인해주세요.");
+    private void redirectToLogin(HttpServletResponse response) throws IOException {
+        response.sendRedirect("/login");
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/auth/token/TokenService.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/token/TokenService.java
@@ -61,13 +61,11 @@ public class TokenService {
         return new Date(System.currentTimeMillis() + tokenExpirationPeriod);
     }
 
-    // TODO: 다른 헤더들도 설정? (캐싱 방지??)
     public void sendAccessToken(HttpServletResponse response, String accessToken) {
         response.setStatus(SC_OK);
         response.setHeader(AUTHORIZATION_HEADER, BEARER_PREFIX + accessToken);
     }
 
-    // TODO: 다른 헤더들도 설정?
     public void sendAccessTokenAndRefreshToken(
         HttpServletResponse response,
         String accessToken,
@@ -77,7 +75,6 @@ public class TokenService {
         response.addCookie(makeRefreshTokenCookie(response, refreshToken));
     }
 
-    // TODO: samesite 옵션?
     private Cookie makeRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
         Cookie cookie = new Cookie(REFRESH_TOKEN_COOKIE, refreshToken);
         cookie.setHttpOnly(true);
@@ -87,7 +84,6 @@ public class TokenService {
         return cookie;
     }
 
-    // TODO: 예외처리
     /**
      * 토큰 만료, 변조 등을 검사합니다.
      */
@@ -116,7 +112,6 @@ public class TokenService {
             .map(Cookie::getValue);
     }
 
-    // TODO: 예외처리
     public Optional<Long> extractUserId(String token) {
         try {
             String subject = JWT.require(HMAC512(secretKey)).build().verify(token).getSubject();
@@ -130,8 +125,6 @@ public class TokenService {
         }
     }
 
-    // TODO: custom exception? transactional?
-    // TODO: updateRefreshToken 로직의 책임을 엔티티, 서비스, 필터 중 어디서?
     @Transactional
     public void updateRefreshToken(Long userId, String refreshToken) {
         userRepository.findById(userId)

--- a/src/main/java/com/stemm/pubsub/service/auth/token/TokenService.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/token/TokenService.java
@@ -125,7 +125,7 @@ public class TokenService {
             log.error("유효한 유저 id가 아닙니다: {}", e.getMessage());
             return Optional.empty();
         } catch (JWTVerificationException e) {
-            log.info("access token이 유효하지 않습니다: {}", e.getMessage());
+            log.error("access token이 유효하지 않습니다: {}", e.getMessage());
             return Optional.empty();
         }
     }

--- a/src/main/java/com/stemm/pubsub/service/auth/token/TokenService.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/token/TokenService.java
@@ -26,6 +26,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 @Getter
 public class TokenService {
 
+    public static final String NICKNAME = "nickname";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
     public static final String REFRESH_TOKEN_COOKIE = "refreshToken";
@@ -43,17 +44,19 @@ public class TokenService {
 
     private final UserRepository userRepository;
 
-    public String createAccessToken(Long userId) {
+    public String createAccessToken(Long userId, String nickname) {
         return JWT.create()
             .withSubject(String.valueOf(userId))
             .withExpiresAt(calculateTokenExpiry(accessTokenExpirationPeriod))
+            .withClaim(NICKNAME, nickname)
             .sign(HMAC512(secretKey));
     }
 
-    public String createRefreshToken(Long userId) {
+    public String createRefreshToken(Long userId, String nickname) {
         return JWT.create()
             .withSubject(String.valueOf(userId))
             .withExpiresAt(calculateTokenExpiry(refreshTokenExpirationPeriod))
+            .withClaim(NICKNAME, nickname)
             .sign(HMAC512(secretKey));
     }
 
@@ -92,7 +95,7 @@ public class TokenService {
             JWT.require(HMAC512(secretKey)).build().verify(token);
             return true;
         } catch (JWTVerificationException e) {
-            log.error("유효하지 않은 토큰입니다. {}", e.getMessage());
+            log.error("유효하지 않은 토큰입니다: {}", e.getMessage());
             return false;
         }
     }
@@ -117,10 +120,25 @@ public class TokenService {
             String subject = JWT.require(HMAC512(secretKey)).build().verify(token).getSubject();
             return Optional.ofNullable(subject).map(Long::valueOf);
         } catch (NumberFormatException e) {
-            log.error("유효한 유저 id가 아닙니다: {}", e.getMessage());
+            log.error("유효하지 않은 유저 id 입니다: {}", e.getMessage());
             return Optional.empty();
         } catch (JWTVerificationException e) {
-            log.error("access token이 유효하지 않습니다: {}", e.getMessage());
+            log.error("유효하지 않은 토큰입니다: {}", e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    public Optional<String> extractNickname(String token) {
+        try {
+            String nickname = JWT.require(HMAC512(secretKey)).build().verify(token).getClaim(NICKNAME).asString();
+
+            if (nickname != null) {
+                return Optional.of(nickname);
+            }
+
+            return Optional.empty();
+        } catch (JWTVerificationException e) {
+            log.error("유효하지 않은 토큰입니다: {}", e.getMessage());
             return Optional.empty();
         }
     }

--- a/src/main/java/com/stemm/pubsub/service/user/entity/User.java
+++ b/src/main/java/com/stemm/pubsub/service/user/entity/User.java
@@ -31,7 +31,7 @@ public class User extends BaseEntity {
     private Membership membership;
 
     @Column(nullable = false, unique = true, length = 100)
-    private String nickname;
+    private String nickname;  // 아이디
 
     @Column(nullable = false)
     private String name;

--- a/src/main/java/com/stemm/pubsub/service/user/repository/user/UserRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/user/repository/user/UserRepository.java
@@ -9,5 +9,4 @@ public interface UserRepository extends JpaRepository<User, Long>, UserInfoRepos
     Optional<User> findByEmail(String email);
     Optional<User> findByNickname(String nickname);
     Optional<User> findByRefreshToken(String refreshToken);
-    Optional<User> findByProviderId(String providerId);
 }

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -2,7 +2,7 @@ jwt:
   secretKey: ${JWT_SECRET_KEY}
 
   access:
-    expiration: 3600000  # 1시간
+    expiration: 1800000  # 30분
 
   refresh:
     expiration: 1209600000  # 2주


### PR DESCRIPTION
## 관련 이슈
- close #26 
- close #30 

<br>

## 작업 내용
- Spring Security, Jwt 기반 로그인/회원가입 기능을 구현했습니다.
- 회원가입 후 /login 요청에서 access token은 헤더로, refresh token은 쿠키로 잘 오는 것을 확인했습니다.
<img width="1150" alt="jwt" src="https://github.com/f-lab-edu/pub-sub/assets/65343417/ef649194-0b48-405e-8b3e-225d71dab189">

<br>

## Auth Flow 정리
- 유저 인증 플로우를 정리해봤습니다.
- 로그인 뿐 아니라, 토큰 인증에서도 `CustomUserDetails`를 principal로 사용하기 위해 `TokenProcessingService`의 유저 인증 로직을 수정했습니다. (기존 코드는 user id만 principal로 사용해 로그인 했을때랑 다른 principal을 사용하게 되는 문제 발생)
<img width="1414" alt="auth-flow" src="https://github.com/f-lab-edu/pub-sub/assets/65343417/cac4779f-f8af-412b-974a-b7c8d7fe1d74">

<br>

## 질문
- `AuthService`의 `validateSignUp`에서 회원가입 중복체크 검사를 위해 db를 각각 접근하는데, 원래 이런 방식으로 구현할 수 밖에 없는걸까요 아니면 제가 놓치고 있는 부분이 있을까요? (매번 db 접근하는게 신경쓰여서요..)
- 위와 같은 느낌의 런타임 예외들을 (뿐만 아니라 기타 런타임 예외들도) 전역으로 잡아볼까 하는데 제가 생각한 방식이 적절할까요?

<br>

## 노트
- 피드백 해주시면 반영하고 인증/인가 관련은 이쯤에서 마무리하겠습니다.
- 다음으로는 전역 에러 처리 및 비즈니스 로직 구현해보겠습니다!