### PR TITLE
전역 예외처리 클래스 구현

### DIFF
--- a/src/main/java/com/stemm/pubsub/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/stemm/pubsub/common/GlobalExceptionHandler.java
@@ -1,0 +1,36 @@
+package com.stemm.pubsub.common;
+
+import com.stemm.pubsub.service.auth.dto.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.stemm.pubsub.service.auth.dto.ApiResponse.error;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Dto validation 예외 처리를 수행하며, 모든 필드 오류를 반환합니다.
+     */
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<List<String>>> handleValidationExceptions(MethodArgumentNotValidException e) {
+        List<String> errors = e.getBindingResult().getFieldErrors()
+            .stream()
+            .map(FieldError::getDefaultMessage)
+            .collect(Collectors.toList());
+
+        log.error("validation error: {}", errors);
+
+        return ResponseEntity
+            .badRequest()
+            .body(error("Validation 예외가 발생했습니다.", errors));
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/auth/AuthController.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.stemm.pubsub.service.auth;
 
+import com.stemm.pubsub.service.auth.dto.ApiResponse;
 import com.stemm.pubsub.service.auth.dto.SignUpRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +9,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.stemm.pubsub.service.auth.dto.ApiResponse.failure;
+import static com.stemm.pubsub.service.auth.dto.ApiResponse.success;
 import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
@@ -17,8 +20,16 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<Object> signUp(@Validated @RequestBody SignUpRequest signUpRequest) throws Exception {
-        authService.signUp(signUpRequest);
-        return ResponseEntity.status(CREATED).build();
+    public ResponseEntity<ApiResponse<Void>> signUp(@Validated @RequestBody SignUpRequest signUpRequest) {
+        try {
+            authService.signUp(signUpRequest);
+            return ResponseEntity
+                .status(CREATED)
+                .body(success("회원가입에 성공하였습니다."));
+        } catch (DuplicateValueException e) {
+            return ResponseEntity
+                .badRequest()
+                .body(failure(e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/auth/dto/ApiResponse.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/dto/ApiResponse.java
@@ -6,21 +6,26 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 
 public record ApiResponse<T>(
     @JsonInclude(NON_EMPTY) String message,
-    @JsonInclude(NON_EMPTY) T data
+    @JsonInclude(NON_EMPTY) T data,
+    @JsonInclude(NON_EMPTY) T error
 ) {
     public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(message, data);
+        return new ApiResponse<>(message, data, null);
     }
 
     public static <T> ApiResponse<T> success(String message) {
-        return new ApiResponse<>(message, null);
+        return new ApiResponse<>(message, null, null);
     }
 
     public static <T> ApiResponse<T> failure(String message, T data) {
-        return new ApiResponse<>(message, data);
+        return new ApiResponse<>(message, data, null);
     }
 
     public static <T> ApiResponse<T> failure(String message) {
-        return new ApiResponse<>(message, null);
+        return new ApiResponse<>(message, null, null);
+    }
+
+    public static <T> ApiResponse<T> error(String message, T error) {
+        return new ApiResponse<>(message, null, error);
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/auth/dto/ApiResponse.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/dto/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.stemm.pubsub.service.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
+public record ApiResponse<T>(
+    @JsonInclude(NON_EMPTY) String message,
+    @JsonInclude(NON_EMPTY) T data
+) {
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(message, data);
+    }
+
+    public static <T> ApiResponse<T> success(String message) {
+        return new ApiResponse<>(message, null);
+    }
+
+    public static <T> ApiResponse<T> failure(String message, T data) {
+        return new ApiResponse<>(message, data);
+    }
+
+    public static <T> ApiResponse<T> failure(String message) {
+        return new ApiResponse<>(message, null);
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/auth/dto/SignUpRequest.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/dto/SignUpRequest.java
@@ -16,7 +16,7 @@ public record SignUpRequest(
     @Email(message = "올바른 이메일 형식이 아닙니다")
     String email,
 
-    @NotBlank(message = "비밀번호를을 입력해주세요.")
+    @NotBlank(message = "비밀번호를 입력해주세요.")
     String password,
 
     String bio

--- a/src/main/java/com/stemm/pubsub/service/user/entity/User.java
+++ b/src/main/java/com/stemm/pubsub/service/user/entity/User.java
@@ -39,6 +39,7 @@ public class User extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(nullable = false)
     private String password;
 
     private String profileImageUrl;


### PR DESCRIPTION
## 관련 이슈
- close #34

<br>

## 작업 내용
- 일관된 응답을 위한 dto인 `ApiResponse`를 정의했습니다.
- `AuthService`에 대한 예외를 `AuthController`에서 처리했습니다.
- `@RestControllerAdvice`를 사용한 전역 예외처리 클래스 `GlobalExceptionHandler`를 구현했습니다.
- 해당 클래스에 dto validation에 대한 예외처리 메서드 `handleValidationExceptions`를 구현했습니다.

<br>

## 질문
1. 피드백 주셨던 부분 반영해서 회원가입 중복 체크에 대한 예외처리는 `AuthController`에서 수행했는데 제가 제대로 이해한 게 맞을까요?
2. `ApiResponse`는 (정의하기 나름이겠지만) 일반적으로 꼭 포함해야하는 값에는 어떤 값들이 있을까요?
3. `ResponseEntity`에 `ApiResponse`를 사용하고 있는데 원래 이렇게 사용하나요? 현업에서는 일반적으로 api 응답을 어떻게 내려주나요?
4. 또한 dto validation은 여러 곳에서 수행될테니 전역으로 처리했는데, 에러 메시지를 내려주는 형태가 적절할까요? 이것도 마찬가지로 정의하기 나름이겠지만 일반적으로 어떻게 내려주나요? 다음은 제가 정의한 형태입니다.
```
{
    "message": "Validation 예외가 발생했습니다.",
    "error": [
        "이름을 입력해주세요.",
        "닉네임을 입력해주세요."
    ]
}
```

<br>

## 노트
- 이제 서비스 계층을 구현할 예정입니다.