### PR TITLE
게시물 컨트롤러, 서비스 계층 구현

### DIFF
--- a/src/main/java/com/stemm/pubsub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/stemm/pubsub/common/exception/GlobalExceptionHandler.java
@@ -1,4 +1,4 @@
-package com.stemm.pubsub.common;
+package com.stemm.pubsub.common.exception;
 
 import com.stemm.pubsub.service.auth.dto.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -32,5 +32,17 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .badRequest()
             .body(error("Validation 예외가 발생했습니다.", errors));
+    }
+
+    /**
+     * 존재하지 않는 유저에 대한 예외를 처리합니다.
+     */
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<Void>> handleUserNotFoundException(UserNotFoundException e) {
+        log.error("존재하지 않는 유저입니다. user id = {}", e.getUserId());
+
+        return ResponseEntity
+            .badRequest()
+            .body(error(e.getMessage()));
     }
 }

--- a/src/main/java/com/stemm/pubsub/common/exception/UserNotFoundException.java
+++ b/src/main/java/com/stemm/pubsub/common/exception/UserNotFoundException.java
@@ -1,0 +1,14 @@
+package com.stemm.pubsub.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class UserNotFoundException extends RuntimeException {
+
+    private final Long userId;
+
+    public UserNotFoundException(Long userId) {
+        super("존재하지 않는 유저입니다.");
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/auth/dto/ApiResponse.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/dto/ApiResponse.java
@@ -13,6 +13,10 @@ public record ApiResponse<T>(
         return new ApiResponse<>(message, data, null);
     }
 
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(null, data, null);
+    }
+
     public static <T> ApiResponse<T> success(String message) {
         return new ApiResponse<>(message, null, null);
     }
@@ -27,5 +31,9 @@ public record ApiResponse<T>(
 
     public static <T> ApiResponse<T> error(String message, T error) {
         return new ApiResponse<>(message, null, error);
+    }
+
+    public static <T> ApiResponse<T> error(String message) {
+        return new ApiResponse<>(message, null, null);
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/post/controller/PostController.java
+++ b/src/main/java/com/stemm/pubsub/service/post/controller/PostController.java
@@ -1,0 +1,55 @@
+package com.stemm.pubsub.service.post.controller;
+
+import com.stemm.pubsub.service.auth.dto.ApiResponse;
+import com.stemm.pubsub.service.auth.userdetails.CustomUserDetails;
+import com.stemm.pubsub.service.post.dto.PostRequest;
+import com.stemm.pubsub.service.post.dto.PostResponse;
+import com.stemm.pubsub.service.post.service.PostNotFoundException;
+import com.stemm.pubsub.service.post.service.PostService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+import static com.stemm.pubsub.service.auth.dto.ApiResponse.error;
+import static com.stemm.pubsub.service.auth.dto.ApiResponse.success;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    // TODO: AuthenticationPrincipal 중복 줄이기?
+    @PostMapping("/posts")
+    public ResponseEntity<ApiResponse<Void>> createPost(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @Validated @RequestBody PostRequest postRequest
+    ) {
+        Long userId = userDetails.getUserId();
+        Long postId = postService.createPost(postRequest, userId);
+
+        return ResponseEntity
+            .created(URI.create("/posts/" + postId))
+            .body(success("게시물이 생성되었습니다."));
+    }
+
+    @GetMapping("/posts/{postId}")
+    public ResponseEntity<ApiResponse<PostResponse>> getPost(@PathVariable Long postId) {
+        try {
+            PostResponse post = postService.getPost(postId);
+            return ResponseEntity.ok(success(post));
+        } catch (PostNotFoundException e) {
+            log.error("존재하지 않는 게시물입니다. post id = {}", e.getPostId());
+            return ResponseEntity
+                .status(NOT_FOUND)
+                .body(error(e.getMessage()));
+        }
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/post/dto/PostRequest.java
+++ b/src/main/java/com/stemm/pubsub/service/post/dto/PostRequest.java
@@ -1,0 +1,15 @@
+package com.stemm.pubsub.service.post.dto;
+
+import com.stemm.pubsub.service.post.entity.post.Visibility;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PostRequest(
+    @NotBlank(message = "내용은 비어 있을 수 없습니다.")
+    String content,
+
+    String imageUrl,
+
+    @NotNull(message = "게시물의 공개 범위는 PUBLIC 또는 PRIVATE 이어야 합니다.")
+    Visibility visibility
+) {}

--- a/src/main/java/com/stemm/pubsub/service/post/dto/PostResponse.java
+++ b/src/main/java/com/stemm/pubsub/service/post/dto/PostResponse.java
@@ -1,0 +1,19 @@
+package com.stemm.pubsub.service.post.dto;
+
+import com.stemm.pubsub.service.post.entity.post.Visibility;
+
+import java.time.LocalDateTime;
+
+public record PostResponse(
+    Long id,
+    String nickname,
+    String profileImageUrl,
+    String content,
+    String imageUrl,
+    Visibility visibility,
+    int likeCount,
+    int dislikeCount,
+    LocalDateTime createdDate,
+    LocalDateTime lastModifiedDate
+) {
+}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostBasicRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostBasicRepository.java
@@ -1,0 +1,10 @@
+package com.stemm.pubsub.service.post.repository.post;
+
+import java.util.Optional;
+
+public interface PostBasicRepository {
+    /**
+     * 게시물에 대한 좋아요 개수까지 함께 불러옵니다.
+     */
+    Optional<PostDto> findPostById(Long postId);
+}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostBasicRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostBasicRepositoryImpl.java
@@ -1,0 +1,46 @@
+package com.stemm.pubsub.service.post.repository.post;
+
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.querydsl.core.types.Projections.constructor;
+import static com.stemm.pubsub.service.post.entity.post.LikeStatus.DISLIKE;
+import static com.stemm.pubsub.service.post.entity.post.LikeStatus.LIKE;
+import static com.stemm.pubsub.service.post.entity.post.QPost.post;
+import static com.stemm.pubsub.service.post.entity.post.QPostLike.postLike;
+
+@RequiredArgsConstructor
+public class PostBasicRepositoryImpl implements PostBasicRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private final ConstructorExpression<PostDto> postDto = constructor(
+        PostDto.class,
+        post.id,
+        post.user.nickname,
+        post.user.profileImageUrl,
+        post.content,
+        post.imageUrl,
+        post.visibility,
+        postLike.status.when(LIKE).then(1).otherwise(0).sum().intValue().as("likeCount"),
+        postLike.status.when(DISLIKE).then(1).otherwise(0).sum().intValue().as("dislikeCount"),
+        post.createdDate,
+        post.lastModifiedDate
+    );
+
+    @Override
+    public Optional<PostDto> findPostById(Long postId) {
+        return Optional.ofNullable(
+            queryFactory
+                .select(postDto)
+                .from(post)
+                .leftJoin(postLike).on(post.id.eq(postLike.post.id))
+                .where(post.id.eq(postId))
+                .groupBy(post.id)
+                .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostDto.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostDto.java
@@ -1,5 +1,7 @@
 package com.stemm.pubsub.service.post.repository.post;
 
+import com.stemm.pubsub.service.post.entity.post.Visibility;
+
 import java.time.LocalDateTime;
 
 public record PostDto(
@@ -8,6 +10,7 @@ public record PostDto(
     String profileImageUrl,
     String content,
     String imageUrl,
+    Visibility visibility,
     int likeCount,
     int dislikeCount,
     LocalDateTime createdDate,

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostRepository.java
@@ -3,5 +3,9 @@ package com.stemm.pubsub.service.post.repository.post;
 import com.stemm.pubsub.service.post.entity.post.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostRepository extends JpaRepository<Post, Long>, PostVisibilityRepository, PostUserRepository {
+public interface PostRepository extends
+    JpaRepository<Post, Long>,
+    PostBasicRepository,
+    PostVisibilityRepository,
+    PostUserRepository {
 }

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepositoryImpl.java
@@ -32,6 +32,7 @@ public class PostUserRepositoryImpl implements PostUserRepository {
         post.user.profileImageUrl,
         post.content,
         post.imageUrl,
+        post.visibility,
         postLike.status.when(LIKE).then(1).otherwise(0).sum().intValue().as("likeCount"),
         postLike.status.when(DISLIKE).then(1).otherwise(0).sum().intValue().as("dislikeCount"),
         post.createdDate,

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImpl.java
@@ -32,6 +32,7 @@ public class PostVisibilityRepositoryImpl implements PostVisibilityRepository {
         post.user.profileImageUrl,
         post.content,
         post.imageUrl,
+        post.visibility,
         postLike.status.when(LIKE).then(1).otherwise(0).sum().intValue().as("likeCount"),
         postLike.status.when(DISLIKE).then(1).otherwise(0).sum().intValue().as("dislikeCount"),
         post.createdDate,

--- a/src/main/java/com/stemm/pubsub/service/post/service/PostNotFoundException.java
+++ b/src/main/java/com/stemm/pubsub/service/post/service/PostNotFoundException.java
@@ -1,0 +1,14 @@
+package com.stemm.pubsub.service.post.service;
+
+import lombok.Getter;
+
+@Getter
+public class PostNotFoundException extends RuntimeException {
+
+    private final Long postId;
+
+    public PostNotFoundException(Long postId) {
+        super("존재하지 않는 게시물입니다.");
+        this.postId = postId;
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/post/service/PostService.java
+++ b/src/main/java/com/stemm/pubsub/service/post/service/PostService.java
@@ -1,0 +1,71 @@
+package com.stemm.pubsub.service.post.service;
+
+import com.stemm.pubsub.common.exception.UserNotFoundException;
+import com.stemm.pubsub.service.post.dto.PostRequest;
+import com.stemm.pubsub.service.post.dto.PostResponse;
+import com.stemm.pubsub.service.post.entity.post.Post;
+import com.stemm.pubsub.service.post.repository.post.PostDto;
+import com.stemm.pubsub.service.post.repository.post.PostRepository;
+import com.stemm.pubsub.service.user.entity.User;
+import com.stemm.pubsub.service.user.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+
+    // TODO: update, delete
+    // TODO: 메인화면에서 쓸 게시물 (public, private) 조회
+
+    @Transactional
+    public Long createPost(PostRequest postRequest, Long userId) {
+        User user = getUser(userId);
+        Post post = toEntity(postRequest, user);
+        Post savedPost = postRepository.save(post);
+        return savedPost.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public PostResponse getPost(Long postId) {
+        PostDto postDto = postRepository.findPostById(postId)
+            .orElseThrow(() -> new PostNotFoundException(postId));
+
+        return toPostResponse(postDto);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new UserNotFoundException(userId));
+    }
+
+    // TODO: 서비스에서 변환 말고 따로
+    private Post toEntity(PostRequest postRequest, User user) {
+        return new Post(
+            user,
+            postRequest.content(),
+            postRequest.imageUrl(),
+            postRequest.visibility()
+        );
+    }
+
+    // TODO: 서비스에서 변환 말고 따로
+    private PostResponse toPostResponse(PostDto postDto) {
+        return new PostResponse(
+            postDto.id(),
+            postDto.nickname(),
+            postDto.profileImageUrl(),
+            postDto.content(),
+            postDto.imageUrl(),
+            postDto.visibility(),
+            postDto.likeCount(),
+            postDto.dislikeCount(),
+            postDto.createdDate(),
+            postDto.lastModifiedDate()
+        );
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,7 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -1,9 +1,0 @@
-spring:
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: 425505287832-5rq19ugtnt96fsi46cg0u9cpmu305i04.apps.googleusercontent.com
-            client-secret: ${GOOGLE_CLIENT_SECRET}
-            scope: profile, email

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,4 +4,4 @@ spring:
     group:
       local: local
       prod: prod
-    include: common, oauth, jwt
+    include: common, jwt


### PR DESCRIPTION
## 관련 이슈
- #24 
- #25 

<br>

## 작업 내용
- 게시물(post)에 대한 컨트롤러 계층과 서비스 계층을 일부(create, read) 구현했습니다.
- 모두 구현하지 않았지만 PR을 올리는 이유는 지금 제대로 구현하고 있는가에 대한 의문과, 코드 양이 많아질 것 같아 한 번 끊었습니다.

<br>

## 질문
1. 일반적으로 현업에서 인증된 유저의 정보(user id)를 컨트롤러 계층에서 넘겨주는 방식을 사용하나요? 저는 spring security에 대한 의존이 결국 어딘가에선 일어나긴 해야하는데, 비즈니스 로직을 순수하게 유지하는게 나을 것 같아서 컨트롤러 계층에서 넘겨주는 방식을 선택했습니다. (간편하기도 하구요...)
2. `handleUserNotFoundException`에서 상태코드 400 내려주는 선택은 어떤가요? (404랑 고민했는데, 400에 좀 더 가깝지 싶어서요)
3. 커스텀 런타임 에러들 정의한 방식 어떤가요? 실제로 이렇게 정의하기도 하나요? user id 같은 경우 외부로 노출하지 않고(로그에서만 사용), 메시지만 내려주기 위해 정의해봤습니다.

<br>

## 노트
- 피드백 반영 후 나머지 update, delete 등 비즈니스 로직 구현해보겠습니다! 감사합니다 :)