### PR TITLE
게시물 서비스 계층 구현

### DIFF
--- a/src/main/java/com/stemm/pubsub/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/stemm/pubsub/common/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.stemm.pubsub.service.auth.dto.ApiResponse.error;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 @Slf4j
 @RestControllerAdvice
@@ -43,6 +44,18 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity
             .badRequest()
+            .body(error(e.getMessage()));
+    }
+
+    /**
+     * 인가되지 않은 유저에 대한 예외를 처리합니다.
+     */
+    @ExceptionHandler
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorizedUserException(UnauthorizedUserException e) {
+        log.error("권한이 없는 유저입니다. user id = {}", e.getUserId());
+
+        return ResponseEntity
+            .status(FORBIDDEN)
             .body(error(e.getMessage()));
     }
 }

--- a/src/main/java/com/stemm/pubsub/common/exception/UnauthorizedUserException.java
+++ b/src/main/java/com/stemm/pubsub/common/exception/UnauthorizedUserException.java
@@ -1,0 +1,14 @@
+package com.stemm.pubsub.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedUserException extends RuntimeException {
+
+    private final Long userId;
+
+    public UnauthorizedUserException(Long userId) {
+        super("권한이 없는 사용자입니다.");
+        this.userId = userId;
+    }
+}

--- a/src/main/java/com/stemm/pubsub/common/exception/UserNotFoundException.java
+++ b/src/main/java/com/stemm/pubsub/common/exception/UserNotFoundException.java
@@ -8,7 +8,7 @@ public class UserNotFoundException extends RuntimeException {
     private final Long userId;
 
     public UserNotFoundException(Long userId) {
-        super("존재하지 않는 유저입니다.");
+        super("존재하지 않는 사용자입니다.");
         this.userId = userId;
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/post/entity/post/Post.java
+++ b/src/main/java/com/stemm/pubsub/service/post/entity/post/Post.java
@@ -41,4 +41,10 @@ public class Post extends BaseEntity {
         this.imageUrl = imageUrl;
         this.visibility = visibility;
     }
+
+    public void update(String content, String imageUrl, Visibility visibility) {
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.visibility = visibility;
+    }
 }

--- a/src/main/java/com/stemm/pubsub/service/post/repository/PostLikeRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/PostLikeRepository.java
@@ -1,7 +1,0 @@
-package com.stemm.pubsub.service.post.repository;
-
-import com.stemm.pubsub.service.post.entity.post.PostLike;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
-}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostBasicRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostBasicRepositoryImpl.java
@@ -20,6 +20,7 @@ public class PostBasicRepositoryImpl implements PostBasicRepository {
     private final ConstructorExpression<PostDto> postDto = constructor(
         PostDto.class,
         post.id,
+        post.user.id,
         post.user.nickname,
         post.user.profileImageUrl,
         post.content,

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostDto.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostDto.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 public record PostDto(
     Long id,
+    Long userId,
     String nickname,
     String profileImageUrl,
     String content,

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepository.java
@@ -3,7 +3,12 @@ package com.stemm.pubsub.service.post.repository.post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface PostUserRepository {
     Page<PostDto> findPublicPostsByUserId(Long userId, Pageable pageable);
     Page<PostDto> findPrivatePostsByUserId(Long userId, Pageable pageable);
+
+    Page<PostDto> findPublicPostsByUserIds(List<Long> userIds, Pageable pageable);
+    Page<PostDto> findPrivatePostsByUserIds(List<Long> userIds, Pageable pageable);
 }

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostUserRepositoryImpl.java
@@ -28,6 +28,7 @@ public class PostUserRepositoryImpl implements PostUserRepository {
     private final ConstructorExpression<PostDto> postDto = constructor(
         PostDto.class,
         post.id,
+        post.user.id,
         post.user.nickname,
         post.user.profileImageUrl,
         post.content,

--- a/src/main/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImpl.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImpl.java
@@ -28,6 +28,7 @@ public class PostVisibilityRepositoryImpl implements PostVisibilityRepository {
     private final ConstructorExpression<PostDto> postDto = constructor(
         PostDto.class,
         post.id,
+        post.user.id,
         post.user.nickname,
         post.user.profileImageUrl,
         post.content,

--- a/src/main/java/com/stemm/pubsub/service/post/repository/postlike/PostLikeDto.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/postlike/PostLikeDto.java
@@ -1,0 +1,11 @@
+package com.stemm.pubsub.service.post.repository.postlike;
+
+public record PostLikeDto(
+    Long postId,
+    int likeCount,
+    int dislikeCount
+) {
+    public PostLikeDto(Long postId, Long likeCount, Long dislikeCount) {
+        this(postId, likeCount.intValue(), dislikeCount.intValue());
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/post/repository/postlike/PostLikeRepository.java
+++ b/src/main/java/com/stemm/pubsub/service/post/repository/postlike/PostLikeRepository.java
@@ -1,0 +1,20 @@
+package com.stemm.pubsub.service.post.repository.postlike;
+
+import com.stemm.pubsub.service.post.entity.post.PostLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    @Query(
+        "select new com.stemm.pubsub.service.post.repository.postlike.PostLikeDto(" +
+            "p.id, " +
+            "sum(case when pl.status = 'LIKE' then 1 else 0 end), " +
+            "sum(case when pl.status = 'DISLIKE' then 1 else 0 end)" +
+        ") " +
+        "from Post p " +
+        "left join PostLike pl on p.id = pl.post.id " +
+        "where p.id = :postId " +
+        "group by p.id"
+    )
+    PostLikeDto findLikeAndDislikeCountByPostId(Long postId);
+}

--- a/src/main/java/com/stemm/pubsub/service/post/service/PostMapper.java
+++ b/src/main/java/com/stemm/pubsub/service/post/service/PostMapper.java
@@ -1,0 +1,61 @@
+package com.stemm.pubsub.service.post.service;
+
+import com.stemm.pubsub.service.post.dto.PostRequest;
+import com.stemm.pubsub.service.post.dto.PostResponse;
+import com.stemm.pubsub.service.post.entity.post.Post;
+import com.stemm.pubsub.service.post.repository.post.PostDto;
+import com.stemm.pubsub.service.post.repository.postlike.PostLikeDto;
+import com.stemm.pubsub.service.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PostMapper {
+
+    public Post toEntity(User user, PostRequest postRequest) {
+        return new Post(
+            user,
+            postRequest.content(),
+            postRequest.imageUrl(),
+            postRequest.visibility()
+        );
+    }
+
+    public Post toEntity(User user, PostDto postDto) {
+        return new Post(
+            user,
+            postDto.content(),
+            postDto.imageUrl(),
+            postDto.visibility()
+        );
+    }
+
+    public PostResponse toPostResponse(PostDto postDto) {
+        return new PostResponse(
+            postDto.id(),
+            postDto.nickname(),
+            postDto.profileImageUrl(),
+            postDto.content(),
+            postDto.imageUrl(),
+            postDto.visibility(),
+            postDto.likeCount(),
+            postDto.dislikeCount(),
+            postDto.createdDate(),
+            postDto.lastModifiedDate()
+        );
+    }
+
+    public PostResponse toPostResponse(Post post, PostLikeDto postLikeDto) {
+        return new PostResponse(
+            post.getId(),
+            post.getUser().getNickname(),
+            post.getUser().getProfileImageUrl(),
+            post.getContent(),
+            post.getImageUrl(),
+            post.getVisibility(),
+            postLikeDto.likeCount(),
+            postLikeDto.dislikeCount(),
+            post.getCreatedDate(),
+            post.getLastModifiedDate()
+        );
+    }
+}

--- a/src/main/java/com/stemm/pubsub/service/post/service/PostService.java
+++ b/src/main/java/com/stemm/pubsub/service/post/service/PostService.java
@@ -10,22 +10,28 @@ import com.stemm.pubsub.service.post.repository.post.PostRepository;
 import com.stemm.pubsub.service.post.repository.postlike.PostLikeDto;
 import com.stemm.pubsub.service.post.repository.postlike.PostLikeRepository;
 import com.stemm.pubsub.service.user.entity.User;
+import com.stemm.pubsub.service.user.repository.subscription.SubscriptionRepository;
+import com.stemm.pubsub.service.user.repository.subscription.dto.SubscriptionUserDto;
 import com.stemm.pubsub.service.user.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
+    private final UserRepository userRepository;
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
-    private final UserRepository userRepository;
+    private final SubscriptionRepository subscriptionRepository;
 
     private final PostMapper postMapper;
-
-    // TODO: 메인화면에서 쓸 게시물 (public, private) 조회
 
     @Transactional
     public Long createPost(PostRequest postRequest, Long userId) {
@@ -56,6 +62,28 @@ public class PostService {
         Post post = getPostEntity(postId);
         validateUser(userId, post);
         postRepository.delete(post);
+    }
+
+    /**
+     * 사용자가 구독 중인 크리에이터의 멤버십(private) 게시물을 조회합니다.
+     */
+    public Page<PostResponse> getSubscribingMembershipPosts(Long userId, Pageable pageable) {
+        SubscriptionUserDto subscribingUserIds = subscriptionRepository.findSubscribingUserIds(userId);
+
+        if (subscribingUserIds.userIds().isEmpty()) {
+            return new PageImpl<>(Collections.emptyList(), pageable, 0);
+        }
+
+        return postRepository.findPrivatePostsByUserIds(subscribingUserIds.userIds(), pageable)
+            .map(postMapper::toPostResponse);
+    }
+
+    /**
+     * 전체 `PUBLIC` 게시물을 조회합니다.
+     */
+    public Page<PostResponse> getAllPublicPosts(Pageable pageable) {
+        return postRepository.findPublicPosts(pageable)
+            .map(postMapper::toPostResponse);
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/com/stemm/pubsub/service/post/service/PostService.java
+++ b/src/main/java/com/stemm/pubsub/service/post/service/PostService.java
@@ -1,11 +1,14 @@
 package com.stemm.pubsub.service.post.service;
 
+import com.stemm.pubsub.common.exception.UnauthorizedUserException;
 import com.stemm.pubsub.common.exception.UserNotFoundException;
 import com.stemm.pubsub.service.post.dto.PostRequest;
 import com.stemm.pubsub.service.post.dto.PostResponse;
 import com.stemm.pubsub.service.post.entity.post.Post;
 import com.stemm.pubsub.service.post.repository.post.PostDto;
 import com.stemm.pubsub.service.post.repository.post.PostRepository;
+import com.stemm.pubsub.service.post.repository.postlike.PostLikeDto;
+import com.stemm.pubsub.service.post.repository.postlike.PostLikeRepository;
 import com.stemm.pubsub.service.user.entity.User;
 import com.stemm.pubsub.service.user.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -17,25 +20,40 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
     private final UserRepository userRepository;
 
-    // TODO: update, delete
     // TODO: 메인화면에서 쓸 게시물 (public, private) 조회
 
     @Transactional
     public Long createPost(PostRequest postRequest, Long userId) {
         User user = getUser(userId);
-        Post post = toEntity(postRequest, user);
+        Post post = toEntity(user, postRequest);
         Post savedPost = postRepository.save(post);
         return savedPost.getId();
     }
 
     @Transactional(readOnly = true)
     public PostResponse getPost(Long postId) {
-        PostDto postDto = postRepository.findPostById(postId)
-            .orElseThrow(() -> new PostNotFoundException(postId));
-
+        PostDto postDto = getPostDto(postId);
         return toPostResponse(postDto);
+    }
+
+    // TODO: like count, dislike count 어떻게 처리하는게 좋을까...
+    @Transactional
+    public PostResponse updatePost(Long userId, Long postId, PostRequest postRequest) {
+        Post post = getPostEntity(postId);
+        validateUser(userId, post);
+        post.update(postRequest.content(), postRequest.imageUrl(), postRequest.visibility());
+        return toPostResponse(post, getPostLikeDto(postId));
+    }
+
+    // TODO: Post 전체가 아닌 id만 가져오도록 변경?
+    @Transactional
+    public void deletePost(Long userId, Long postId) {
+        Post post = getPostEntity(postId);
+        validateUser(userId, post);
+        postRepository.delete(post);
     }
 
     private User getUser(Long userId) {
@@ -43,8 +61,28 @@ public class PostService {
             .orElseThrow(() -> new UserNotFoundException(userId));
     }
 
-    // TODO: 서비스에서 변환 말고 따로
-    private Post toEntity(PostRequest postRequest, User user) {
+    private void validateUser(Long userId, Post post) {
+        if (!userId.equals(post.getUser().getId())) {
+            throw new UnauthorizedUserException(userId);
+        }
+    }
+
+    private PostDto getPostDto(Long postId) {
+        return postRepository.findPostById(postId)
+            .orElseThrow(() -> new PostNotFoundException(postId));
+    }
+
+    private Post getPostEntity(Long postId) {
+        return postRepository.findById(postId)
+            .orElseThrow(() -> new PostNotFoundException(postId));
+    }
+
+    private PostLikeDto getPostLikeDto(Long postId) {
+        return postLikeRepository.findLikeAndDislikeCountByPostId(postId);
+    }
+
+    // TODO: 변환 메서드들 서비스에서 말고 따로
+    private Post toEntity(User user, PostRequest postRequest) {
         return new Post(
             user,
             postRequest.content(),
@@ -53,7 +91,15 @@ public class PostService {
         );
     }
 
-    // TODO: 서비스에서 변환 말고 따로
+    private Post toEntity(User user, PostDto postDto) {
+        return new Post(
+            user,
+            postDto.content(),
+            postDto.imageUrl(),
+            postDto.visibility()
+        );
+    }
+
     private PostResponse toPostResponse(PostDto postDto) {
         return new PostResponse(
             postDto.id(),
@@ -66,6 +112,21 @@ public class PostService {
             postDto.dislikeCount(),
             postDto.createdDate(),
             postDto.lastModifiedDate()
+        );
+    }
+
+    private PostResponse toPostResponse(Post post, PostLikeDto postLikeDto) {
+        return new PostResponse(
+            post.getId(),
+            post.getUser().getNickname(),
+            post.getUser().getProfileImageUrl(),
+            post.getContent(),
+            post.getImageUrl(),
+            post.getVisibility(),
+            postLikeDto.likeCount(),
+            postLikeDto.dislikeCount(),
+            post.getCreatedDate(),
+            post.getLastModifiedDate()
         );
     }
 }

--- a/src/main/java/com/stemm/pubsub/service/post/service/PostService.java
+++ b/src/main/java/com/stemm/pubsub/service/post/service/PostService.java
@@ -23,12 +23,14 @@ public class PostService {
     private final PostLikeRepository postLikeRepository;
     private final UserRepository userRepository;
 
+    private final PostMapper postMapper;
+
     // TODO: 메인화면에서 쓸 게시물 (public, private) 조회
 
     @Transactional
     public Long createPost(PostRequest postRequest, Long userId) {
         User user = getUser(userId);
-        Post post = toEntity(user, postRequest);
+        Post post = postMapper.toEntity(user, postRequest);
         Post savedPost = postRepository.save(post);
         return savedPost.getId();
     }
@@ -36,7 +38,7 @@ public class PostService {
     @Transactional(readOnly = true)
     public PostResponse getPost(Long postId) {
         PostDto postDto = getPostDto(postId);
-        return toPostResponse(postDto);
+        return postMapper.toPostResponse(postDto);
     }
 
     // TODO: like count, dislike count 어떻게 처리하는게 좋을까...
@@ -45,7 +47,7 @@ public class PostService {
         Post post = getPostEntity(postId);
         validateUser(userId, post);
         post.update(postRequest.content(), postRequest.imageUrl(), postRequest.visibility());
-        return toPostResponse(post, getPostLikeDto(postId));
+        return postMapper.toPostResponse(post, getPostLikeDto(postId));
     }
 
     // TODO: Post 전체가 아닌 id만 가져오도록 변경?
@@ -79,54 +81,5 @@ public class PostService {
 
     private PostLikeDto getPostLikeDto(Long postId) {
         return postLikeRepository.findLikeAndDislikeCountByPostId(postId);
-    }
-
-    // TODO: 변환 메서드들 서비스에서 말고 따로
-    private Post toEntity(User user, PostRequest postRequest) {
-        return new Post(
-            user,
-            postRequest.content(),
-            postRequest.imageUrl(),
-            postRequest.visibility()
-        );
-    }
-
-    private Post toEntity(User user, PostDto postDto) {
-        return new Post(
-            user,
-            postDto.content(),
-            postDto.imageUrl(),
-            postDto.visibility()
-        );
-    }
-
-    private PostResponse toPostResponse(PostDto postDto) {
-        return new PostResponse(
-            postDto.id(),
-            postDto.nickname(),
-            postDto.profileImageUrl(),
-            postDto.content(),
-            postDto.imageUrl(),
-            postDto.visibility(),
-            postDto.likeCount(),
-            postDto.dislikeCount(),
-            postDto.createdDate(),
-            postDto.lastModifiedDate()
-        );
-    }
-
-    private PostResponse toPostResponse(Post post, PostLikeDto postLikeDto) {
-        return new PostResponse(
-            post.getId(),
-            post.getUser().getNickname(),
-            post.getUser().getProfileImageUrl(),
-            post.getContent(),
-            post.getImageUrl(),
-            post.getVisibility(),
-            postLikeDto.likeCount(),
-            postLikeDto.dislikeCount(),
-            post.getCreatedDate(),
-            post.getLastModifiedDate()
-        );
     }
 }

--- a/src/test/java/com/stemm/pubsub/common/IntegrationTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/IntegrationTestSupport.java
@@ -2,6 +2,8 @@ package com.stemm.pubsub.common;
 
 import com.stemm.pubsub.service.post.repository.post.PostRepository;
 import com.stemm.pubsub.service.post.service.PostService;
+import com.stemm.pubsub.service.user.repository.membership.MembershipRepository;
+import com.stemm.pubsub.service.user.repository.subscription.SubscriptionRepository;
 import com.stemm.pubsub.service.user.repository.user.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,6 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 public abstract class IntegrationTestSupport {
     @Autowired
     protected UserRepository userRepository;
+
+    @Autowired
+    protected MembershipRepository membershipRepository;
+
+    @Autowired
+    protected SubscriptionRepository subscriptionRepository;
 
     @Autowired
     protected PostRepository postRepository;

--- a/src/test/java/com/stemm/pubsub/common/IntegrationTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/IntegrationTestSupport.java
@@ -1,0 +1,21 @@
+package com.stemm.pubsub.common;
+
+import com.stemm.pubsub.service.post.repository.post.PostRepository;
+import com.stemm.pubsub.service.post.service.PostService;
+import com.stemm.pubsub.service.user.repository.user.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public abstract class IntegrationTestSupport {
+    @Autowired
+    protected UserRepository userRepository;
+
+    @Autowired
+    protected PostRepository postRepository;
+
+    @Autowired
+    protected PostService postService;
+}

--- a/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/RepositoryTestSupport.java
@@ -1,9 +1,9 @@
 package com.stemm.pubsub.common;
 
 import com.stemm.pubsub.common.config.QuerydslConfig;
-import com.stemm.pubsub.service.post.repository.PostLikeRepository;
 import com.stemm.pubsub.service.post.repository.comment.CommentRepository;
 import com.stemm.pubsub.service.post.repository.post.PostRepository;
+import com.stemm.pubsub.service.post.repository.postlike.PostLikeRepository;
 import com.stemm.pubsub.service.user.repository.membership.MembershipRepository;
 import com.stemm.pubsub.service.user.repository.subscription.SubscriptionRepository;
 import com.stemm.pubsub.service.user.repository.user.UserRepository;

--- a/src/test/java/com/stemm/pubsub/service/post/repository/comment/CommentPostRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/repository/comment/CommentPostRepositoryImplTest.java
@@ -49,6 +49,7 @@ class CommentPostRepositoryImplTest extends RepositoryTestSupport {
             .nickname("nickname")
             .name("name")
             .email("user@me.com")
+            .password("password")
             .build();
     }
 }

--- a/src/test/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/repository/post/PostVisibilityRepositoryImplTest.java
@@ -103,6 +103,7 @@ class PostVisibilityRepositoryImplTest extends RepositoryTestSupport {
             .nickname(nickname)
             .name(name)
             .email(email)
+            .password("password")
             .build();
     }
 }

--- a/src/test/java/com/stemm/pubsub/service/post/service/PostServiceTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/service/PostServiceTest.java
@@ -1,0 +1,197 @@
+package com.stemm.pubsub.service.post.service;
+
+import com.stemm.pubsub.common.IntegrationTestSupport;
+import com.stemm.pubsub.common.exception.UnauthorizedUserException;
+import com.stemm.pubsub.common.exception.UserNotFoundException;
+import com.stemm.pubsub.service.post.dto.PostRequest;
+import com.stemm.pubsub.service.post.dto.PostResponse;
+import com.stemm.pubsub.service.post.entity.post.Post;
+import com.stemm.pubsub.service.post.entity.post.Visibility;
+import com.stemm.pubsub.service.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.stemm.pubsub.service.post.entity.post.Visibility.PRIVATE;
+import static com.stemm.pubsub.service.post.entity.post.Visibility.PUBLIC;
+import static org.assertj.core.api.Assertions.*;
+
+class PostServiceTest extends IntegrationTestSupport {
+
+    User user1;
+    User user2;
+
+    @BeforeEach
+    void setUp() {
+        user1 = createUser("user1", "username1", "user1@me.com");
+        user2 = createUser("user2", "username2", "user2@me.com");
+        userRepository.saveAll(List.of(user1, user2));
+    }
+
+    @Test
+    @DisplayName("신규 게시물을 생성합니다.")
+    void createPost() {
+        // given
+        PostRequest postRequest = createPostRequest("content", PRIVATE);
+
+        // when
+        Long postId = postService.createPost(postRequest, user1.getId());
+
+        // then
+        Post post = postRepository.findById(postId).get();
+        assertThat(postId).isEqualTo(post.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자는 게시물을 생성할 수 없습니다.")
+    void cantCreatePost() {
+        // given
+        PostRequest postRequest = createPostRequest("content", PRIVATE);
+
+        // when & then
+        assertThatThrownBy(() -> postService.createPost(postRequest, 100L))
+            .isInstanceOf(UserNotFoundException.class)
+            .hasMessage("존재하지 않는 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("특정 게시물을 조회합니다.")
+    void getPost() {
+        // given
+        Post post1 = createPost(user1, "post1", PRIVATE);
+        Post post2 = createPost(user1, "post2", PRIVATE);
+        postRepository.saveAll(List.of(post1, post2));
+
+        // when
+        PostResponse postResponse = postService.getPost(post1.getId());
+
+        // then
+        assertThat(postResponse)
+            .extracting("id", "content", "visibility", "likeCount", "dislikeCount")
+            .contains(post1.getId(), postResponse.content(), postResponse.visibility(), 0, 0);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시물은 조회할 수 없습니다.")
+    void cantGetPost() {
+        // given
+        Post post1 = createPost(user1, "post1", PRIVATE);
+        Post post2 = createPost(user1, "post2", PRIVATE);
+        postRepository.saveAll(List.of(post1, post2));
+
+        // when & then
+        assertThatThrownBy(() -> postService.getPost(100L))
+            .isInstanceOf(PostNotFoundException.class)
+            .hasMessage("존재하지 않는 게시물입니다.");
+    }
+
+    @Test
+    @DisplayName("게시물을 수정합니다.")
+    void updatePost() {
+        // given
+        Post post = createPost(user1, "post1", PRIVATE);
+        Post savedPost = postRepository.save(post);
+        PostRequest postRequest = createPostRequest("update post", PUBLIC);
+
+        // when
+        PostResponse postResponse = postService.updatePost(user1.getId(), savedPost.getId(), postRequest);
+
+        // then
+        assertThat(postResponse)
+            .extracting("content", "visibility")
+            .contains("update post", PUBLIC);
+    }
+
+    @Test
+    @DisplayName("본인이 아니면 게시물을 수정할 수 없습니다.")
+    void cantUpdateOtherUsersPost() {
+        // given
+        Post post = createPost(user1, "post1", PRIVATE);
+        Post savedPost = postRepository.save(post);
+        PostRequest postRequest = createPostRequest("update post", PUBLIC);
+
+        // when & then
+        assertThatThrownBy(() -> postService.updatePost(user2.getId(), savedPost.getId(), postRequest))
+            .isInstanceOf(UnauthorizedUserException.class)
+            .hasMessage("권한이 없는 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 게시물은 수정할 수 없습니다")
+    void cantUpdateNonExistingPost() {
+        // given
+        PostRequest postRequest = createPostRequest("update post", PUBLIC);
+
+        // when & then
+        assertThatThrownBy(() -> postService.updatePost(user1.getId(), -1L, postRequest))
+            .isInstanceOf(PostNotFoundException.class)
+            .hasMessage("존재하지 않는 게시물입니다.");
+    }
+
+    @Test
+    @DisplayName("게시물을 삭제합니다.")
+    void deletePost() {
+        // given
+        Post post1 = createPost(user1, "post1", PRIVATE);
+        Post post2 = createPost(user1, "post2", PRIVATE);
+        postRepository.saveAll(List.of(post1, post2));
+
+        // when
+        postService.deletePost(user1.getId(), post1.getId());
+
+        // then
+        List<Post> posts = postRepository.findAll();
+
+        assertThat(posts)
+            .hasSize(1)
+            .extracting("content", "visibility")
+            .containsExactly(tuple("post2", PRIVATE));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시물은 삭제할 수 없습니다.")
+    void cantDeleteNonExistingPost() {
+        // given
+        Post post1 = createPost(user1, "post1", PRIVATE);
+        Post post2 = createPost(user1, "post2", PRIVATE);
+        postRepository.saveAll(List.of(post1, post2));
+
+        // when & then
+        assertThatThrownBy(() -> postService.deletePost(user1.getId(), -1L))
+            .isInstanceOf(PostNotFoundException.class)
+            .hasMessage("존재하지 않는 게시물입니다.");
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 게시물은 삭제할 수 없습니다.")
+    void cantDeleteOtherUsersPost() {
+        // given
+        Post post1 = createPost(user1, "post1", PRIVATE);
+        Post post2 = createPost(user1, "post2", PRIVATE);
+        postRepository.saveAll(List.of(post1, post2));
+
+        // when & then
+        assertThatThrownBy(() -> postService.deletePost(user2.getId(), post1.getId()))
+            .isInstanceOf(UnauthorizedUserException.class)
+            .hasMessage("권한이 없는 사용자입니다.");
+    }
+
+    private User createUser(String nickname, String name, String email) {
+        return User.builder()
+            .nickname(nickname)
+            .name(name)
+            .email(email)
+            .password("password")
+            .build();
+    }
+
+    private Post createPost(User user, String content, Visibility visibility) {
+        return new Post(user, content, null, visibility);
+    }
+
+    private PostRequest createPostRequest(String content, Visibility visibility) {
+        return new PostRequest(content, null, visibility);
+    }
+}

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionTimeRepositoryImplTest.java
@@ -80,6 +80,7 @@ class SubscriptionTimeRepositoryImplTest extends RepositoryTestSupport {
             .nickname("a")
             .name("user")
             .email("a@me.com")
+            .password("password")
             .build();
     }
 }

--- a/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/subscription/SubscriptionUserRepositoryImplTest.java
@@ -48,6 +48,7 @@ class SubscriptionUserRepositoryImplTest extends RepositoryTestSupport {
             .name(name)
             .email(email)
             .membership(membership)
+            .password("password")
             .build();
     }
 }

--- a/src/test/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImplTest.java
+++ b/src/test/java/com/stemm/pubsub/service/user/repository/user/UserInfoRepositoryImplTest.java
@@ -50,6 +50,7 @@ class UserInfoRepositoryImplTest extends RepositoryTestSupport {
             .nickname(nickname)
             .name(name)
             .email(email)
+            .password("password")
             .build();
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,3 +10,12 @@ spring:
   sql:
     init:
       mode: never
+
+jwt:
+  secretKey: ${JWT_SECRET_KEY}
+
+  access:
+    expiration: 1800000  # 30분
+
+  refresh:
+    expiration: 1209600000  # 2주


### PR DESCRIPTION
## 관련 이슈
- close #24 

<br>

## 작업 내용
- `PostService`를 구현했습니다.
- `PostServiceTest`를 작성했습니다.
- TDD 방식으로 일부 기능을 구현해보았습니다.

<br>

## 질문
1. 게시물 수정 로직(`updatePost` 메서드)
    - 방법 1(현재): post 엔티티를 불러옴 -> 엔티티 update -> 엔티티는 post like가 없으므로 따로 쿼리 -> post + post like 리턴하는 방식으로 구현되었는데 어떤가요? select는 3번(user, post, postlike) update 1번 수행합니다. 
    - 방법 2(post dto 사용): dto는 dirty checking이 안되므로 엔티티로 변환 후 영속 상태로 만들고 업데이트 해야하는데, 이때 user 객체가 필요해짐(2번의 select와 1번의 update가 나갈것으로 예상). 이 과정에서 서비스 계층에서 명시적으로 영속 상태로 만들어줘야 하는 부분 때문에 뭔가 구현이 애매해지는것 같아 최초 방식 채택
    - post dto를 사용하면 like count를 가져오니깐 성능은 좀 더 좋을 것 같긴한데 어떻게 생각하시나요?
2. 페이징을 위한 `Page`를 현재 모든 계층에서 의존하고 있는데, 이정도 의존성은 괜찮다고 보시나요? 현업에서는 따로 또 페이징을 위한 dto를 만들어서 사용하나요?
3. 여러 테스트를 한번에 실행 할때 db에 값을 넣다 뺐다 하는 과정에서 트랜잭션 롤백이 되어도 auto increment 때문에 id 값이 계속 올라가 예상하지 못한 id 값이 나오는 문제는 어떻게 처리하면 좋을까요? (e.g. `createPost` 메서드의 then 절에서는 리포지토리에서 찾아와서 id 값을 사용하고 있는데 올바르게 테스트 작성했다고 보시나요?)
4. 취향차이 같긴한데 테스트 then 절에서 결과값 확인을 위해 리터럴을 사용하는 것과 getter로 값을 비교하는 것 중 어떤게 더 낫다고 보시나요? (가독성은 리터럴이 좋은것 같은데, 위의 id 같은 문제 때문에 신경쓰여서요...)
5. 현재 작성한 테스트 코드처럼 이렇게 각 메서드에 대해 다 테스트를 작성하는게 맞나요? (기본 테스트 + 예외 케이스 테스트 각각)
6. dto 매퍼를 간단하게 만들어봤는데 에전에 말씀하셨던게 이런 형태가 맞을까요? (인터페이스 만들어서 하는것도 고려는 했는데... 굳이 불필요가 느껴져서 일단 간단하게만 구현해봤습니다.)

<br>

## 노트
- 1번 질문은 뭔가 텍스트로 표현하기 애매해서 잘 설명했는지 모르겠습니다. 이해 안되시면 말씀해주세요!
- 게시물 컨트롤러 계층 구현해보겠습니다. 감사합니다 :)
