### PR TITLE
게시물 컨트롤러 계층 테스트 작성

### DIFF
--- a/src/main/java/com/stemm/pubsub/service/post/dto/PostRequest.java
+++ b/src/main/java/com/stemm/pubsub/service/post/dto/PostRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record PostRequest(
-    @NotBlank(message = "내용은 비어 있을 수 없습니다.")
+    @NotBlank(message = "게시물의 내용은 비어 있을 수 없습니다.")
     String content,
 
     String imageUrl,

--- a/src/test/java/com/stemm/pubsub/common/ControllerTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/ControllerTestSupport.java
@@ -1,0 +1,46 @@
+package com.stemm.pubsub.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stemm.pubsub.common.security.WithMockCustomUser;
+import com.stemm.pubsub.service.post.controller.PostController;
+import com.stemm.pubsub.service.post.service.PostService;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+
+@WebMvcTest(controllers = PostController.class)
+@WithMockCustomUser
+public abstract class ControllerTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected PostService postService;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @PostConstruct
+    public void setUpMockMvc() {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply(springSecurity())
+            .defaultRequest(get("/**").with(csrf()))
+            .defaultRequest(post("/**").with(csrf()))
+            .defaultRequest(patch("/**").with(csrf()))
+            .defaultRequest(delete("/**").with(csrf()))
+            .build();
+    }
+}

--- a/src/test/java/com/stemm/pubsub/common/security/WithMockCustomUser.java
+++ b/src/test/java/com/stemm/pubsub/common/security/WithMockCustomUser.java
@@ -1,0 +1,15 @@
+package com.stemm.pubsub.common.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    String nickname() default "nickname";
+    String username() default "username";
+    String email() default "nickname@email.com";
+    String password() default "password";
+}

--- a/src/test/java/com/stemm/pubsub/common/security/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/stemm/pubsub/common/security/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,40 @@
+package com.stemm.pubsub.common.security;
+
+import com.stemm.pubsub.service.auth.userdetails.CustomUserDetails;
+import com.stemm.pubsub.service.user.entity.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import static com.stemm.pubsub.service.user.entity.Role.USER;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser customUser) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        User user = User.builder()
+            .id(1L)
+            .nickname(customUser.nickname())
+            .name(customUser.username())
+            .email(customUser.email())
+            .password(customUser.password())
+            .role(USER)
+            .build();
+
+        CustomUserDetails principal = new CustomUserDetails(user);
+
+        Authentication auth = UsernamePasswordAuthenticationToken.authenticated(
+            principal,
+            null,
+            principal.getAuthorities()
+        );
+
+        context.setAuthentication(auth);
+
+        return context;
+    }
+}

--- a/src/test/java/com/stemm/pubsub/service/post/controller/PostControllerTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/controller/PostControllerTest.java
@@ -87,10 +87,6 @@ class PostControllerTest extends ControllerTestSupport {
             .andExpect(jsonPath("$.message").value("게시물이 생성되었습니다."));
     }
 
-    private PostResponse createPostResponse(Long id, String nickname, String content, Visibility visibility) {
-        return new PostResponse(id, nickname, null, content, null, visibility, 0, 0, now(), now());
-    }
-
     @Test
     @DisplayName("게시물의 내용은 비어 있을 수 없습니다.")
     void cantCreatePostWithEmptyContent() throws Exception {
@@ -123,5 +119,9 @@ class PostControllerTest extends ControllerTestSupport {
             .andDo(print())
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.error[0]").value("게시물의 공개 범위는 PUBLIC 또는 PRIVATE 이어야 합니다."));
+    }
+
+    private PostResponse createPostResponse(Long id, String nickname, String content, Visibility visibility) {
+        return new PostResponse(id, nickname, null, content, null, visibility, 0, 0, now(), now());
     }
 }

--- a/src/test/java/com/stemm/pubsub/service/post/controller/PostControllerTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/controller/PostControllerTest.java
@@ -1,0 +1,127 @@
+package com.stemm.pubsub.service.post.controller;
+
+import com.stemm.pubsub.common.ControllerTestSupport;
+import com.stemm.pubsub.service.post.dto.PostRequest;
+import com.stemm.pubsub.service.post.dto.PostResponse;
+import com.stemm.pubsub.service.post.entity.post.Visibility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.stemm.pubsub.service.post.entity.post.Visibility.PRIVATE;
+import static com.stemm.pubsub.service.post.entity.post.Visibility.PUBLIC;
+import static java.time.LocalDateTime.now;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class PostControllerTest extends ControllerTestSupport {
+
+    @Test
+    @DisplayName("전체 `PUBLIC` 게시물을 조회합니다.")
+    void getAllPublicPosts() throws Exception {
+        // given
+        List<PostResponse> posts = List.of(
+            createPostResponse(1L, "nickname1", "content1", PUBLIC),
+            createPostResponse(2L, "nickname2", "content2", PUBLIC),
+            createPostResponse(3L, "nickname3", "content3", PUBLIC)
+        );
+        Page<PostResponse> page = new PageImpl<>(posts);
+
+        given(postService.getAllPublicPosts(any(Pageable.class)))
+            .willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.content").isArray());
+    }
+
+    @Test
+    @DisplayName("사용자가 구독 중인 크리에이터의 멤버십(private) 게시물을 조회합니다.")
+    void getSubscribingMembershipPosts() throws Exception {
+        // given
+        List<PostResponse> posts = List.of(
+            createPostResponse(1L, "nickname1", "content1", PRIVATE),
+            createPostResponse(2L, "nickname2", "content2", PRIVATE),
+            createPostResponse(3L, "nickname3", "content3", PRIVATE)
+        );
+        Page<PostResponse> page = new PageImpl<>(posts);
+
+        given(postService.getSubscribingMembershipPosts(anyLong(), any(Pageable.class)))
+            .willReturn(page);
+
+        // when & then
+        mockMvc.perform(get("/subscribed"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.content").isArray());
+    }
+
+    @Test
+    @DisplayName("게시물을 생성합니다.")
+    void createPost() throws Exception {
+        // given
+        PostRequest postRequest = new PostRequest("content1", null, PUBLIC);
+
+        // when & then
+        mockMvc
+            .perform(
+                post("/posts")
+                    .content(objectMapper.writeValueAsString(postRequest))
+                    .contentType(APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.message").value("게시물이 생성되었습니다."));
+    }
+
+    private PostResponse createPostResponse(Long id, String nickname, String content, Visibility visibility) {
+        return new PostResponse(id, nickname, null, content, null, visibility, 0, 0, now(), now());
+    }
+
+    @Test
+    @DisplayName("게시물의 내용은 비어 있을 수 없습니다.")
+    void cantCreatePostWithEmptyContent() throws Exception {
+        // given
+        PostRequest postRequest = new PostRequest("", null, PUBLIC);
+
+        // when & then
+        mockMvc.perform(
+                post("/posts")
+                    .content(objectMapper.writeValueAsString(postRequest))
+                    .contentType(APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error[0]").value("게시물의 내용은 비어 있을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("게시물의 공개 범위는 PUBLIC 또는 PRIVATE 이어야 합니다.")
+    void cantCreatePostWithoutVisibility() throws Exception {
+        // given
+        PostRequest postRequest = new PostRequest("content", null, null);
+
+        // when & then
+        mockMvc.perform(
+                post("/posts")
+                    .content(objectMapper.writeValueAsString(postRequest))
+                    .contentType(APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.error[0]").value("게시물의 공개 범위는 PUBLIC 또는 PRIVATE 이어야 합니다."));
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- close #25 

<br>

## 작업 내용
- `PostContoller`에 대한 테스트 코드를 작성했습니다.
- Spring Security와 함께 테스트하기 위해 `@WithMockCustomUser` 어노테이션을 정의해 security context를 간편하게 설정할 수 있도록 했습니다.

<br>

## 질문
- `@MockBean`을 사용해 `PostService`를 모킹했는데, 어떤 경우는 테스트 코드 내에서 stubbing 해주고, 어떤 경우는 해주지 않아도 되는 것 같은데 그 기준이 어떻게 될까요? (저는 서비스 계층에서 굳이 특별한 값을 받고싶은 경우가 아니면 하지 않았는데, 맞게 한건지 궁금합니다.)

<br>

## 노트
- 이제 Spring REST Docs 세팅할 예정입니다.
