### PR TITLE
Spring REST Docs 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.2.3'
 	id 'io.spring.dependency-management' version '1.1.4'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.stemm'
@@ -15,6 +16,7 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+    asciidoctorExt
 }
 
 repositories {
@@ -34,7 +36,11 @@ dependencies {
     implementation 'com.auth0:java-jwt:4.4.0'
     testImplementation 'org.springframework.security:spring-security-test'
 
-	// Lombok
+    // Rest Docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
@@ -60,4 +66,29 @@ tasks.named('test') {
 
 clean {
 	delete file('src/main/generated')
+}
+
+ext {  // 전역 변수
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    dependsOn test
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    sources {
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile()
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,14 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= PubSub REST API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[Post-API]]
+== Post API
+include::post/post.adoc[]

--- a/src/docs/asciidoc/post/post.adoc
+++ b/src/docs/asciidoc/post/post.adoc
@@ -1,0 +1,20 @@
+[[product-create]]
+
+=== 모든 PUBLIC 게시물 조회
+==== HTTP Request
+include::{snippets}/getAllPublicPosts/http-request.adoc[]
+include::{snippets}/getAllPublicPosts/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/getAllPublicPosts/http-response.adoc[]
+include::{snippets}/getAllPublicPosts/response-fields.adoc[]
+
+
+=== 게시물 등록
+==== HTTP Request
+include::{snippets}/createPost/http-request.adoc[]
+include::{snippets}/createPost/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/createPost/http-response.adoc[]
+include::{snippets}/createPost/response-fields.adoc[]

--- a/src/main/java/com/stemm/pubsub/service/auth/SecurityConfig.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
         return http
             .authorizeHttpRequests(registry -> registry
                 .requestMatchers("/css/**", "/images/**", "/js/**", "/favicon.ico").permitAll()
-                .requestMatchers("/h2-console/**", "/error").permitAll()
+                .requestMatchers("/docs/**", "/h2-console/**", "/error").permitAll()
                 .requestMatchers("/login", "/signup").permitAll()
                 .anyRequest().authenticated()
             )

--- a/src/main/java/com/stemm/pubsub/service/auth/token/TokenProcessingFilter.java
+++ b/src/main/java/com/stemm/pubsub/service/auth/token/TokenProcessingFilter.java
@@ -25,7 +25,7 @@ import static com.stemm.pubsub.service.user.entity.Role.USER;
 @RequiredArgsConstructor
 public class TokenProcessingFilter extends OncePerRequestFilter {
 
-    private static final String[] whitelist = {"/signup", "/login"};
+    private static final String[] whitelist = {"/signup", "/login", "/docs/**"};
 
     private final TokenService tokenService;
     private final UserDetailsService customUserDetailsService;

--- a/src/test/java/com/stemm/pubsub/common/ControllerTestSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/ControllerTestSupport.java
@@ -15,6 +15,7 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 @WebMvcTest(controllers = PostController.class)
 @WithMockCustomUser
@@ -41,6 +42,7 @@ public abstract class ControllerTestSupport {
             .defaultRequest(post("/**").with(csrf()))
             .defaultRequest(patch("/**").with(csrf()))
             .defaultRequest(delete("/**").with(csrf()))
+            .alwaysDo(print())
             .build();
     }
 }

--- a/src/test/java/com/stemm/pubsub/common/docs/PostControllerDocsTest.java
+++ b/src/test/java/com/stemm/pubsub/common/docs/PostControllerDocsTest.java
@@ -1,0 +1,124 @@
+package com.stemm.pubsub.common.docs;
+
+import com.stemm.pubsub.service.post.dto.PostRequest;
+import com.stemm.pubsub.service.post.dto.PostResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+import static com.stemm.pubsub.service.post.entity.post.Visibility.PUBLIC;
+import static java.time.LocalDateTime.now;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.JsonFieldType.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class PostControllerDocsTest extends RestDocsSupport {
+
+    @Test
+    @DisplayName("전체 `PUBLIC` 게시물을 조회합니다.")
+    void getAllPublicPosts() throws Exception {
+        List<PostResponse> posts = List.of(
+            createPostResponse()
+        );
+        Page<PostResponse> page = new PageImpl<>(posts);
+
+        given(postService.getAllPublicPosts(any(Pageable.class)))
+            .willReturn(page);
+
+        mockMvc.perform(get("/"))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.content").isArray())
+            .andDo(
+                document(
+                    "getAllPublicPosts",
+                    queryParameters(
+                        parameterWithName("page").optional().description("페이지 번호"),
+                        parameterWithName("size").optional().description("페이지 크기")
+                    ),
+                    responseFields(
+                        fieldWithPath("data.content.[]").type(ARRAY).description("게시물 목록"),
+                        fieldWithPath("data.content.[].id").type(NUMBER).description("게시물 ID"),
+                        fieldWithPath("data.content.[].nickname").type(STRING).description("닉네임"),
+                        fieldWithPath("data.content.[].profileImageUrl").type(STRING).optional().description("프로필 이미지 Url"),
+                        fieldWithPath("data.content.[].content").type(STRING).description("내용"),
+                        fieldWithPath("data.content.[].imageUrl").type(STRING).optional().description("이미지 URL"),
+                        fieldWithPath("data.content.[].visibility").type(STRING).description("공개 범위(PRIVATE, PUBLIC)"),
+                        fieldWithPath("data.content.[].likeCount").type(NUMBER).description("좋아요 수"),
+                        fieldWithPath("data.content.[].dislikeCount").type(NUMBER).description("싫어요 수"),
+                        fieldWithPath("data.content.[].createdDate").type(STRING).description("생성 날짜"),
+                        fieldWithPath("data.content.[].lastModifiedDate").type(STRING).description("마지막 수정 날짜"),
+                        fieldWithPath("data.totalPages").type(NUMBER).description("전체 페이지 수"),
+                        fieldWithPath("data.totalElements").type(NUMBER).description("전체 게시물 수"),
+                        fieldWithPath("data.pageable").type(STRING).description("현재 페이지에 대한 Pageable 인스턴스"),
+                        fieldWithPath("data.last").type(BOOLEAN).description("마지막 페이지 여부"),
+                        fieldWithPath("data.first").type(BOOLEAN).description("첫번째 페이지 여부"),
+                        fieldWithPath("data.size").type(NUMBER).description("페이지에 있는 데이터 개수"),
+                        fieldWithPath("data.number").type(NUMBER).description("현재 페이지 번호"),
+                        fieldWithPath("data.sort").type(OBJECT).description("Sort 객체"),
+                        fieldWithPath("data.sort.empty").type(BOOLEAN).description("empty"),
+                        fieldWithPath("data.sort.sorted").type(BOOLEAN).description("sorted"),
+                        fieldWithPath("data.sort.unsorted").type(BOOLEAN).description("unsorted"),
+                        fieldWithPath("data.numberOfElements").type(NUMBER).description("현재 페이지에 실제로 있는 데이터 수"),
+                        fieldWithPath("data.empty").type(BOOLEAN).description("현재 페이지가 비어있는지 여부")
+                    )
+                )
+            );
+    }
+
+    @Test
+    @DisplayName("게시물을 생성합니다.")
+    void createPost() throws Exception {
+        PostRequest postRequest = new PostRequest("content", null, PUBLIC);
+
+        given(postService.createPost(any(PostRequest.class), anyLong()))
+            .willReturn(1L);
+
+        mockMvc
+            .perform(
+                post("/posts")
+                    .content(objectMapper.writeValueAsString(postRequest))
+                    .contentType(APPLICATION_JSON)
+            )
+            .andDo(print())
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.message").value("게시물이 생성되었습니다."))
+            .andDo(
+                document(
+                    "createPost",
+                    responseHeaders(
+                        headerWithName("Location").description("생성된 게시물 Uri")
+                    ),
+                    requestFields(
+                        fieldWithPath("content").type(STRING).description("상품 타입"),
+                        fieldWithPath("imageUrl").type(STRING).optional().description("이미지 Url"),
+                        fieldWithPath("visibility").type(STRING).description("공개 범위")
+                    ),
+                    responseFields(
+                        fieldWithPath("message").type(STRING).description("메시지")
+                    )
+                )
+            );
+    }
+
+    private PostResponse createPostResponse() {
+        return new PostResponse(1L, "nickname", null, "content of the post", null, PUBLIC, 0, 0, now(), now());
+    }
+}

--- a/src/test/java/com/stemm/pubsub/common/docs/RestDocsSupport.java
+++ b/src/test/java/com/stemm/pubsub/common/docs/RestDocsSupport.java
@@ -1,0 +1,47 @@
+package com.stemm.pubsub.common.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.stemm.pubsub.common.security.WithMockCustomUser;
+import com.stemm.pubsub.service.post.controller.PostController;
+import com.stemm.pubsub.service.post.service.PostService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@ExtendWith(RestDocumentationExtension.class)
+@WebMvcTest(PostController.class)
+@WithMockCustomUser
+public abstract class RestDocsSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected PostService postService;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider provider) {
+        mockMvc = MockMvcBuilders
+            .webAppContextSetup(webApplicationContext)
+            .apply(
+                documentationConfiguration(provider)
+                    .operationPreprocessors()
+                    .withRequestDefaults(prettyPrint())
+                    .withResponseDefaults(prettyPrint())
+            )
+            .build();
+    }
+}

--- a/src/test/java/com/stemm/pubsub/service/post/controller/PostControllerTest.java
+++ b/src/test/java/com/stemm/pubsub/service/post/controller/PostControllerTest.java
@@ -21,7 +21,6 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -43,7 +42,6 @@ class PostControllerTest extends ControllerTestSupport {
 
         // when & then
         mockMvc.perform(get("/"))
-            .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.content").isArray());
     }
@@ -64,7 +62,6 @@ class PostControllerTest extends ControllerTestSupport {
 
         // when & then
         mockMvc.perform(get("/subscribed"))
-            .andDo(print())
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.content").isArray());
     }
@@ -82,7 +79,6 @@ class PostControllerTest extends ControllerTestSupport {
                     .content(objectMapper.writeValueAsString(postRequest))
                     .contentType(APPLICATION_JSON)
             )
-            .andDo(print())
             .andExpect(status().isCreated())
             .andExpect(jsonPath("$.message").value("게시물이 생성되었습니다."));
     }
@@ -103,7 +99,6 @@ class PostControllerTest extends ControllerTestSupport {
                     .content(objectMapper.writeValueAsString(postRequest))
                     .contentType(APPLICATION_JSON)
             )
-            .andDo(print())
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.error[0]").value("게시물의 내용은 비어 있을 수 없습니다."));
     }
@@ -120,7 +115,6 @@ class PostControllerTest extends ControllerTestSupport {
                     .content(objectMapper.writeValueAsString(postRequest))
                     .contentType(APPLICATION_JSON)
             )
-            .andDo(print())
             .andExpect(status().isBadRequest())
             .andExpect(jsonPath("$.error[0]").value("게시물의 공개 범위는 PUBLIC 또는 PRIVATE 이어야 합니다."));
     }

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,14 @@
+==== Request Fields
+|===
+|Path|Type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,14 @@
+==== Response Fields
+|===
+|Path|Type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===


### PR DESCRIPTION
## 관련 이슈
- close #47 

<br>

## 작업 내용
- 신뢰성 있는 API 문서를 위해 Spring REST Docs를 도입했습니다.
- 커스텀 템플릿을 사용해 문서를 원하는 형태로 작성했습니다.
<img width="1585" alt="스크린샷 2024-04-27 오후 5 34 03" src="https://github.com/f-lab-edu/pub-sub/assets/65343417/2b1b44c2-a488-469a-8564-147a523dc59c">

<br>

## 질문
- 현업에서 rest docs를 사용하면 이를 위한 테스트 클래스를 따로 작성하나요? (저는 너무 길어지는것 같아 따로 작성해보았습니다.)
- 막상 써보니깐 이것도 swagger랑 결이 다를뿐이지 번잡한데, 실무에서는 일반적으로 어떤 형태로 API 문서를 작성하나요? (솔직히 둘 다 좋은지 잘 모르겠네요...)

<br>

## 노트
- Docker 공부 및 도입할 예정입니다.
